### PR TITLE
fix: text-to-image swanlab_logger

### DIFF
--- a/diffsynth/trainers/text_to_image.py
+++ b/diffsynth/trainers/text_to_image.py
@@ -294,7 +294,7 @@ def launch_training_task(model, args):
             mode=args.swanlab_mode,
             logdir=args.output_path,
         )
-        logger = [swanlab_config]
+        logger = [swanlab_logger]
     else:
         logger = []
 


### PR DESCRIPTION
This pull request includes a small change to the `launch_training_task` function in the `diffsynth/trainers/text_to_image.py` file. The change updates the logger configuration to use `swanlab_logger` instead of `swanlab_config`. 

* [`diffsynth/trainers/text_to_image.py`](diffhunk://#diff-bfe6e82762abf6730d82be82deb8c61bee346f1a882ac3f938b4f47b1513e0feL297-R297): Updated the logger configuration to use `swanlab_logger` instead of `swanlab_config`.