### PR TITLE
Modify the swanlab `logdir` location

### DIFF
--- a/diffsynth/trainers/text_to_image.py
+++ b/diffsynth/trainers/text_to_image.py
@@ -290,7 +290,7 @@ def launch_training_task(model, args):
             name="diffsynth_studio",
             config=swanlab_config,
             mode=args.swanlab_mode,
-            logdir=args.output_path,
+            logdir=os.path.join(args.output_path, "swanlog"),
         )
         logger = [swanlab_logger]
     else:

--- a/examples/wanvideo/train_wan_t2v.py
+++ b/examples/wanvideo/train_wan_t2v.py
@@ -501,7 +501,7 @@ def train(args):
             name="wan",
             config=swanlab_config,
             mode=args.swanlab_mode,
-            logdir=args.output_path,
+            logdir=os.path.join(args.output_path, "swanlog"),
         )
         logger = [swanlab_logger]
     else:


### PR DESCRIPTION
SwanLab保存日志文件的逻辑中，`logdir`参数指定的是存放多个实验目录的文件夹位置，包含每个实验目录`run-xxx`和数据库文件`swanlab.xxx`，将它们用1个独立的`swanlog`目录装起来，更有利于整理输出。