### PR TITLE
cd0319-ImportError-libX11.so.6

### DIFF
--- a/diffsynth/extensions/ImageQualityMetric/open_clip/factory.py
+++ b/diffsynth/extensions/ImageQualityMetric/open_clip/factory.py
@@ -5,7 +5,7 @@ import pathlib
 import re
 from copy import deepcopy
 from pathlib import Path
-from turtle import forward
+# from turtle import forward
 from typing import Any, Dict, Optional, Tuple, Union
 
 import torch


### PR DESCRIPTION
注释掉了/DiffSynth-Studio/diffsynth/extensions/ImageQualityMetric/open_clip/factory.py中的from turtle import forward