### PR TITLE
Fix wan T2V inference with larger batchsize than 1

### DIFF
--- a/diffsynth/pipelines/wan_video.py
+++ b/diffsynth/pipelines/wan_video.py
@@ -581,7 +581,7 @@ def model_fn_wan_video(
         if tea_cache is not None:
             tea_cache.store(x)
 
-    x = dit.head(x, t)
+    x = dit.head(x, t.unsqueeze(1))
     if use_unified_sequence_parallel:
         if dist.is_initialized() and dist.get_world_size() > 1:
             x = get_sp_group().all_gather(x, dim=1)

--- a/diffsynth/prompters/wan_prompter.py
+++ b/diffsynth/prompters/wan_prompter.py
@@ -105,5 +105,5 @@ class WanPrompter(BasePrompter):
         seq_lens = mask.gt(0).sum(dim=1).long()
         prompt_emb = self.text_encoder(ids, mask)
         for i, v in enumerate(seq_lens):
-            prompt_emb[:, v:] = 0
+            prompt_emb[i, v:] = 0
         return prompt_emb


### PR DESCRIPTION
Currently Wan2 T2V inference fails on batchsize larger than 1 due to 

1. Incompatiable shape between the time conditioning and the modulation tensor
2. A bug in the text encoder that truncate the text to the smallest text token length available in the batch.

I introduced two small fixes but I am not sure if other inference/training behaviors are also affected (e.g I2V).