### PR TITLE
fix a bug in sliding_window inference

### DIFF
--- a/diffsynth/pipelines/wan_video_new.py
+++ b/diffsynth/pipelines/wan_video_new.py
@@ -1012,12 +1012,16 @@ class TemporalTiler_BCTHW:
     def __init__(self):
         pass
 
-    def build_1d_mask(self, length, left_bound, right_bound, border_width):
+    def build_1d_mask(length, left_bound, right_bound, border_width):
         x = torch.ones((length,))
+        if border_width == 0:
+            return x
+        
+        shift = 0.5
         if not left_bound:
-            x[:border_width] = (torch.arange(border_width) + 1) / border_width
+            x[:border_width] = (torch.arange(border_width) + shift) / border_width
         if not right_bound:
-            x[-border_width:] = torch.flip((torch.arange(border_width) + 1) / border_width, dims=(0,))
+            x[-border_width:] = torch.flip((torch.arange(border_width) + shift) / border_width, dims=(0,))
         return x
 
     def build_mask(self, data, is_bound, border_width):
@@ -1047,7 +1051,7 @@ class TemporalTiler_BCTHW:
             mask = self.build_mask(
                 model_output,
                 is_bound=(t == 0, t_ == T),
-                border_width=(sliding_window_size - sliding_window_stride + 1,)
+                border_width=(sliding_window_size - sliding_window_stride,)
             ).to(device=data_device, dtype=data_dtype)
             value[:, :, t: t_, :, :] += model_output * mask
             weight[:, :, t: t_, :, :] += mask

--- a/diffsynth/pipelines/wan_video_new.py
+++ b/diffsynth/pipelines/wan_video_new.py
@@ -1047,7 +1047,7 @@ class TemporalTiler_BCTHW:
             mask = self.build_mask(
                 model_output,
                 is_bound=(t == 0, t_ == T),
-                border_width=(sliding_window_size - sliding_window_stride,)
+                border_width=(sliding_window_size - sliding_window_stride + 1,)
             ).to(device=data_device, dtype=data_dtype)
             value[:, :, t: t_, :, :] += model_output * mask
             weight[:, :, t: t_, :, :] += mask


### PR DESCRIPTION
I found that there is a small bug in the sliding_window script, where when `sliding_window_size=sliding_window_stride` will throw an error and the weight map is not right otherwise.
I wrote a minimum replicable code block as follows from the original `wan_video_new.py`.
```python
import torch
from einops import repeat

T = 11
sliding_window_size = 5
sliding_window_stride = 4
# sliding_window_stride = 5

def build_1d_mask(length, left_bound, right_bound, border_width):
    x = torch.ones((length,))
    if not left_bound:
        x[:border_width] = (torch.arange(border_width) + 1) / border_width
    if not right_bound:
        x[-border_width:] = torch.flip((torch.arange(border_width) + 1) / border_width, dims=(0,))
    return x

def build_mask(T, is_bound, border_width):
    # _, _, T, _, _ = data.shape
    t = build_1d_mask(T, is_bound[0], is_bound[1], border_width[0])
    mask = repeat(t, "T -> 1 1 T 1 1")
    return mask

for t in range(0, T, sliding_window_stride):
    if t - sliding_window_stride >= 0 and t - sliding_window_stride + sliding_window_size >= T:
        continue
    t_ = min(t + sliding_window_size, T)

    mask = build_mask(
        sliding_window_size,
        is_bound=(t == 0, t_ == T),
        border_width=(sliding_window_size - sliding_window_stride,)
    )
    print(t, t_, mask.flatten())

>>> 0 5 tensor([1., 1., 1., 1., 1.])
>>> 4 9 tensor([1., 1., 1., 1., 1.])
>>> 8 11 tensor([1., 1., 1., 1., 1.])
# the overlaped 1 is not weighted, causing artifacts generated in the overlapping frames
```