### PR TITLE
Fix batch decoding for Wan-Video-VAE

### DIFF
--- a/diffsynth/models/wan_video_vae.py
+++ b/diffsynth/models/wan_video_vae.py
@@ -1234,11 +1234,18 @@ class WanVideoVAE(nn.Module):
 
 
     def decode(self, hidden_states, device, tiled=False, tile_size=(34, 34), tile_stride=(18, 16)):
-        if tiled:
-            video = self.tiled_decode(hidden_states, device, tile_size, tile_stride)
-        else:
-            video = self.single_decode(hidden_states, device)
-        return video
+        hidden_states = [hidden_state.to("cpu") for hidden_state in hidden_states]
+        videos = []
+        for hidden_state in hidden_states:
+            hidden_state = hidden_state.unsqueeze(0)
+            if tiled:
+                video = self.tiled_decode(hidden_state, device, tile_size, tile_stride)
+            else:
+                video = self.single_decode(hidden_state, device)
+            video = video.squeeze(0)
+            videos.append(video)
+        videos = torch.stack(videos)
+        return videos
 
 
     @staticmethod

--- a/diffsynth/models/wan_video_vae.py
+++ b/diffsynth/models/wan_video_vae.py
@@ -1216,7 +1216,6 @@ class WanVideoVAE(nn.Module):
 
 
     def encode(self, videos, device, tiled=False, tile_size=(34, 34), tile_stride=(18, 16)):
-
         videos = [video.to("cpu") for video in videos]
         hidden_states = []
         for video in videos:


### PR DESCRIPTION
The Wan-VAE decoding for batch sizes > 1 was broken after 830b1b7. We may roll it back.

```shell
values[
    :,
    :,
    :,
    target_h:target_h + hidden_states_batch.shape[3],
    target_w:target_w + hidden_states_batch.shape[4],
] += hidden_states_batch * mask
*** RuntimeError: output with shape [1, 3, 5, 416, 240] doesn't match the broadcast shape [2, 3, 5, 416, 240]
```

in which

```shell
values [1, 3, 5, 416, 240]
hidden_states_batch [2, 3, 5, 416, 240]
```