### PR TITLE
Fix gradient checkpointing in WAN VACE blocks

### DIFF
--- a/diffsynth/pipelines/wan_video_new.py
+++ b/diffsynth/pipelines/wan_video_new.py
@@ -1243,7 +1243,11 @@ def model_fn_wan_video(
         tea_cache_update = False
         
     if vace_context is not None:
-        vace_hints = vace(x, vace_context, context, t_mod, freqs)
+        vace_hints = vace(
+            x, vace_context, context, t_mod, freqs,
+            use_gradient_checkpointing=use_gradient_checkpointing,
+            use_gradient_checkpointing_offload=use_gradient_checkpointing_offload
+        )
     
     # blocks
     if use_unified_sequence_parallel:


### PR DESCRIPTION
When using the accelerate config and training script provided by the repository, an **Out of Memory** error occurs when training **WAN VACE 14B** with 8 * 80G A800 GPUs at 480p and 81 frames. Upon inspection, the `use_gradient_checkpointing_offload` specified in the script does not affect the forward pass of the VACE blocks. This pr fixes the issue.