### PR TITLE
Fix sinusoidal_embedding calculation for bf16 precision. 

### DIFF
--- a/diffsynth/models/wan_video_dit.py
+++ b/diffsynth/models/wan_video_dit.py
@@ -362,7 +362,7 @@ class WanModel(torch.nn.Module):
                 **kwargs,
                 ):
         t = self.time_embedding(
-            sinusoidal_embedding_1d(self.freq_dim, timestep))
+            sinusoidal_embedding_1d(self.freq_dim, timestep).to(x.dtype))
         t_mod = self.time_projection(t).unflatten(1, (6, self.dim))
         context = self.text_embedding(context)
         


### PR DESCRIPTION
The Wan DiT uses bf16 precision during training, so `sinusoidal_embedding_1d()` is required to return a bf16 tensor. `sinusoidal_embedding_1d()` casts its result to the dtype of the input `timestep`. This implies that the input `timestep` must be a bf16 tensor.

However, `timestep` is in the range `[0, 1000]`. Casting it to bf16 causes significant precision loss. For example:

```sh
ipdb> self.pipe.scheduler.timesteps[timestep_id]
tensor([998.3897])
ipdb> self.pipe.scheduler.timesteps[timestep_id].to(torch.bfloat16)
tensor([1000.], dtype=torch.bfloat16)
```

Therefore, `timestep` should be kept in fp32, and only cast to `x.dtype` before feeding it into the `self.time_embedding` layer.

Please let me know if there’s a better approach, thanks!