### PR TITLE
Update Qwen-Image-Edit-2509.py

### DIFF
--- a/examples/qwen_image/model_inference_low_vram/Qwen-Image-Edit-2509.py
+++ b/examples/qwen_image/model_inference_low_vram/Qwen-Image-Edit-2509.py
@@ -21,6 +21,7 @@ pipe = QwenImagePipeline.from_pretrained(
         ModelConfig(model_id="Qwen/Qwen-Image", origin_file_pattern="text_encoder/model*.safetensors", **vram_config),
         ModelConfig(model_id="Qwen/Qwen-Image", origin_file_pattern="vae/diffusion_pytorch_model.safetensors", **vram_config),
     ],
+    tokenizer_config=ModelConfig(model_id="Qwen/Qwen-Image-Edit", origin_file_pattern="tokenizer/"),
     processor_config=ModelConfig(model_id="Qwen/Qwen-Image-Edit", origin_file_pattern="processor/"),
     vram_limit=torch.cuda.mem_get_info("cuda")[1] / (1024 ** 3) - 0.5,
 )


### PR DESCRIPTION
Not adding this line will result in the following error：

’TypeError: expected str, bytes or os.PathLike object, not NoneType‘