### PR TITLE
fix: Add MPS and CPU device support

### DIFF
--- a/diffsynth/core/vram/layers.py
+++ b/diffsynth/core/vram/layers.py
@@ -64,7 +64,11 @@ class AutoTorchModule(torch.nn.Module):
 
     def check_free_vram(self):
         device = self.computation_device if self.computation_device != "npu" else "npu:0"
-        gpu_mem_state = getattr(torch, self.computation_device_type).mem_get_info(device)
+        device_module = getattr(torch, self.computation_device_type, None)
+        # Only CUDA and NPU have mem_get_info, for MPS/CPU assume enough memory
+        if device_module is None or not hasattr(device_module, "mem_get_info"):
+            return True
+        gpu_mem_state = device_module.mem_get_info(device)
         used_memory = (gpu_mem_state[1] - gpu_mem_state[0]) / (1024**3)
         return used_memory < self.vram_limit
 

--- a/diffsynth/diffusion/base_pipeline.py
+++ b/diffsynth/diffusion/base_pipeline.py
@@ -155,7 +155,10 @@ class BasePipeline(torch.nn.Module):
                             for module in model.modules():
                                 if hasattr(module, "offload"):
                                     module.offload()
-            getattr(torch, self.device_type).empty_cache()
+            # Clear cache if available (only CUDA has empty_cache)
+            device_module = getattr(torch, self.device_type, None)
+            if device_module is not None and hasattr(device_module, "empty_cache"):
+                device_module.empty_cache()
             # onload models
             for name, model in self.named_children():
                 if name in model_names:

--- a/diffsynth/models/dinov3_image_encoder.py
+++ b/diffsynth/models/dinov3_image_encoder.py
@@ -70,7 +70,10 @@ class DINOv3ImageEncoder(DINOv3ViTModel):
             }
         )
         
-    def forward(self, image, torch_dtype=torch.bfloat16, device="cuda"):
+    def forward(self, image, torch_dtype=torch.bfloat16, device=None):
+        # Use model's device if not specified
+        if device is None:
+            device = next(self.parameters()).device
         inputs = self.processor(images=image, return_tensors="pt")
         pixel_values = inputs["pixel_values"].to(dtype=torch_dtype, device=device)
         bool_masked_pos = None

--- a/diffsynth/models/siglip2_image_encoder.py
+++ b/diffsynth/models/siglip2_image_encoder.py
@@ -47,7 +47,10 @@ class Siglip2ImageEncoder(SiglipVisionTransformer):
             }
         )
         
-    def forward(self, image, torch_dtype=torch.bfloat16, device="cuda"):
+    def forward(self, image, torch_dtype=torch.bfloat16, device=None):
+        # Use model's device if not specified
+        if device is None:
+            device = next(self.parameters()).device
         pixel_values = self.processor(images=[image], return_tensors="pt")["pixel_values"]
         pixel_values = pixel_values.to(device=device, dtype=torch_dtype)
         output_attentions = False


### PR DESCRIPTION
## Summary

This PR adds support for running DiffSynth-Studio on Apple Silicon (MPS) and CPU devices, which currently fails with various AttributeError exceptions.

### Changes

1. **diffsynth/diffusion/base_pipeline.py**: Check if `empty_cache()` method exists before calling it (only CUDA has this)

2. **diffsynth/models/siglip2_image_encoder.py**: Change `device` parameter default from `"cuda"` to `None`, auto-detect from model parameters

3. **diffsynth/models/dinov3_image_encoder.py**: Same fix as above

4. **diffsynth/core/vram/layers.py**: Check if `mem_get_info()` method exists before calling it (only CUDA/NPU have this)

### Issues Fixed

- `AttributeError: module 'torch.cpu' has no attribute 'empty_cache'`
- `AttributeError: module 'torch.mps' has no attribute 'empty_cache'`
- `AttributeError: module 'torch.cpu' has no attribute 'mem_get_info'`
- `AttributeError: module 'torch.mps' has no attribute 'mem_get_info'`
- `AssertionError: Torch not compiled with CUDA enabled` (from hardcoded cuda in encoders)

### Test Plan

- [x] Tested on macOS with MPS device
- [x] LoRA training works correctly
- [x] Image generation works correctly