### PR TITLE
Update package inclusion pattern in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 
 [tool.setuptools.packages.find]
 where = ["./"]
-include = ["diffsynth*"]
+include = ["diffsynth", "diffsynth.*"]
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
Update to install all the sub-packages inside `diffsynth`. Otherwise, the installed `diffsynth` package only contains `__init__.py`, but not contains other site-packages like `core`, `diffusion`, etc.