### PR TITLE
[bug fix] fix multi-gpu model loading bug

### DIFF
--- a/diffsynth/core/loader/file.py
+++ b/diffsynth/core/loader/file.py
@@ -15,6 +15,10 @@ def load_state_dict(file_path, torch_dtype=None, device="cpu"):
 
 
 def load_state_dict_from_safetensors(file_path, torch_dtype=None, device="cpu"):
+    import torch.distributed as dist
+    from diffsynth.core.device.npu_compatible_device import get_device_name, IS_NPU_AVAILABLE, IS_CUDA_AVAILABLE
+    if dist.is_available() and dist.is_initialized() and (IS_CUDA_AVAILABLE or IS_NPU_AVAILABLE):
+        device = get_device_name()
     state_dict = {}
     with safe_open(file_path, framework="pt", device=str(device)) as f:
         for k in f.keys():

--- a/diffsynth/core/vram/disk_map.py
+++ b/diffsynth/core/vram/disk_map.py
@@ -28,11 +28,12 @@ class SafetensorsCompatibleBinaryLoader:
 class DiskMap:
 
     def __init__(self, path, device, torch_dtype=None, state_dict_converter=None, buffer_size=10**9):
+        import torch.distributed as dist
+        from diffsynth.core.device.npu_compatible_device import get_device_name, IS_NPU_AVAILABLE, IS_CUDA_AVAILABLE
+        if dist.is_available() and dist.is_initialized() and (IS_CUDA_AVAILABLE or IS_NPU_AVAILABLE):
+            device = get_device_name()
         self.path = path if isinstance(path, list) else [path]
         self.device = device
-        import torch.distributed as dist
-        if dist.is_available() and dist.is_initialized() and str(self.device).strip() == "cuda":
-            self.device = f"cuda:{torch.cuda.current_device()}"
         self.torch_dtype = torch_dtype
         if os.environ.get('DIFFSYNTH_DISK_MAP_BUFFER_SIZE') is not None:
             self.buffer_size = int(os.environ.get('DIFFSYNTH_DISK_MAP_BUFFER_SIZE'))


### PR DESCRIPTION
As mentioned in the following issue, the current code has model loading bug when running on multi-gpus. When launching the script with torchrun, the model loading logic incorrectly places all model weights on GPU 0 (cuda:0). This centralizes the memory load on a single GPU and results in an OOM error.
#1075 
<img width="1441" height="59" alt="截屏2026-01-10 12 26 29" src="https://github.com/user-attachments/assets/91549e58-1f7a-4a58-9821-a44a877711a1" />

I've modified the code in [diffsynth/core/vram/disk_map.py] . I updated the safetensors model loading method within the DiskMap class to ensure proper GPU device mapping when loading the model for multi-GPU inference.
Root cause:
The safetensors library interprets the device 'cuda' as Device 0 (cuda:0) by default. Unlike native PyTorch functions, it does not automatically follow the current device context set by torch.cuda.set_device().
