### PR TITLE
fix RMSNorm precision

### DIFF
--- a/diffsynth/models/z_image_dit.py
+++ b/diffsynth/models/z_image_dit.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.utils.rnn import pad_sequence
 
-from torch.nn import RMSNorm
+from .general_modules import RMSNorm
 from ..core.attention import attention_forward
 from ..core.device.npu_compatible_device import IS_NPU_AVAILABLE
 from ..core.gradient import gradient_checkpoint_forward


### PR DESCRIPTION
This is a perplexing precision issue: RMSNorm in PyTorch introduces slight numerical variations in the tensor. Although these are nearly imperceptible in the generated image, there is always a minor difference.