### PR TITLE
Fix AttributeError when pipe.dit is None during split training

### DIFF
--- a/diffsynth/pipelines/z_image.py
+++ b/diffsynth/pipelines/z_image.py
@@ -296,7 +296,7 @@ class ZImageUnit_PromptEmbedder(PipelineUnit):
 
     def process(self, pipe: ZImagePipeline, prompt, edit_image):
         pipe.load_models_to_device(self.onload_model_names)
-        if hasattr(pipe, "dit") and pipe.dit.siglip_embedder is not None:
+        if hasattr(pipe, "dit") and pipe.dit is not None and pipe.dit.siglip_embedder is not None:
             # Z-Image-Turbo and Z-Image-Omni-Base use different prompt encoding methods.
             # We determine which encoding method to use based on the model architecture.
             # If you are using two-stage split training,


### PR DESCRIPTION
## Summary
- Fixes AttributeError: 'NoneType' object has no attribute 'siglip_embedder' when using split training with `sft:data_process` task
- Adds explicit None check before accessing `pipe.dit.siglip_embedder`

## Problem
When using split training as documented in [Split_Training.md](https://github.com/modelscope/DiffSynth-Studio/blob/main/docs/zh/Training/Split_Training.md), the DiT model is not loaded during the first phase (data processing), but the `dit` attribute exists with value `None`.

The existing code:
```python
if hasattr(pipe, "dit") and pipe.dit.siglip_embedder is not None:
```

`hasattr(pipe, "dit")` returns `True` because the attribute exists, but accessing `pipe.dit.siglip_embedder` fails because `pipe.dit` is `None`.

## Solution
Add an explicit None check:
```python
if hasattr(pipe, "dit") and pipe.dit is not None and pipe.dit.siglip_embedder is not None:
```

## Test plan
- [ ] Run split training with `--task "sft:data_process"` without loading the DiT model

Fixes #1246