### PR TITLE
fix: WanVAE2.2 encode and decode error

### DIFF
--- a/diffsynth/models/wan_video_vae.py
+++ b/diffsynth/models/wan_video_vae.py
@@ -1336,7 +1336,6 @@ class VideoVAE38_(VideoVAE_):
         x = self.conv2(z)
         for i in range(iter_):
             self._conv_idx = [0]
-            # breakpoint()
             if i == 0:
                 out, self._feat_map, self._conv_idx = self.decoder(x[:, :, i:i + 1, :, :],
                                    feat_cache=self._feat_map,


### PR DESCRIPTION
我正在 Wan2.2-TI2V-5B 上展开实验，但我发现最近对 WanVAE 的调整 https://github.com/modelscope/DiffSynth-Studio/commit/4e9db263b0ec953dc3f12833cd343d09b20441dc https://github.com/modelscope/DiffSynth-Studio/commit/6886f7ba352252f83ad7eff7ffbeeb7917c29e38 导致原本可以运行的代码失效了。我的修复逻辑如下：

1. 对于我的第一个 commit：WanVAE2.2 在 encode 阶段的下采样过程中，调用了 Resample38 类的 forward，由于 Resample38 继承自 Resample，且 Resample 的 forward 方法返回三元组 `x, feat_cache, feat_idx`，所以 Resample38 的前向传播结果需要三元组来收集。WanVAE2.2 的 decode 阶段也调用了 Resample38 类的 forward，所以同理。
2. 对于我的第二个 commit：经过实验，我发现解码上采样的过程中始终需要 Up_ResidualBlock 类返回三元组，根据最近对 WanVAE 代码的调整，我估计原作者忘记添加了。