### PR TITLE
修复训练循环中 `optimizer.zero_grad()` 顺序错误导致的梯度累积问题

### DIFF
--- a/diffsynth/diffusion/runner.py
+++ b/diffsynth/diffusion/runner.py
@@ -33,15 +33,15 @@ def launch_training_task(
     for epoch_id in range(num_epochs):
         for data in tqdm(dataloader):
             with accelerator.accumulate(model):
-                optimizer.zero_grad()
                 if dataset.load_from_cache:
                     loss = model({}, inputs=data)
                 else:
                     loss = model(data)
                 accelerator.backward(loss)
                 optimizer.step()
-                model_logger.on_step_end(accelerator, model, save_steps, loss=loss)
                 scheduler.step()
+                optimizer.zero_grad()
+                model_logger.on_step_end(accelerator, model, save_steps, loss=loss)
         if save_steps is None:
             model_logger.on_epoch_end(accelerator, model, epoch_id)
     model_logger.on_training_end(accelerator, model, save_steps)


### PR DESCRIPTION


### 变更内容

这个 PR 将训练循环中的 `optimizer.zero_grad()` 从 `accelerator.accumulate(model)` 的开头移动到 `optimizer.step()` 和 `scheduler.step()` 之后。

### 问题背景

当前代码大致如下：

```python

with accelerator.accumulate(model):

    optimizer.zero_grad()

    loss = ...

    accelerator.backward(loss)

    optimizer.step()

    scheduler.step()

```

这种写法在开启梯度累积时可能有问题。

在梯度累积场景下，前几个 micro-step 的梯度本来应该保留下来，等累积完成后再统一更新。  

但如果一进入 `accumulate()` 就先执行 `optimizer.zero_grad()`，那么在某些 step 上，前面已经累积的梯度可能会在真正更新前被清掉。

这样会导致在 `gradient_accumulation_steps > 1` 时，参数更新实际使用的可能不是累积后的梯度，而更接近于最后一个 micro-batch 的梯度。

虽然训练过程中 loss 仍然可能下降，所以这个问题不一定容易直接发现，但梯度累积的行为可能已经不符合预期。

### 修复方式

将代码调整为：

```python

with accelerator.accumulate(model):

    loss = ...

    accelerator.backward(loss)

    optimizer.step()

    scheduler.step()

    optimizer.zero_grad()

```

### 修复效果

- 修复开启梯度累积时可能存在的错误行为

- 保证梯度在完成参数更新后再清零

- 使训练循环更符合 Accelerate 的常见使用方式

- 对 `gradient_accumulation_steps = 1` 的场景没有行为变化