### PR TITLE
flux2: dual-GPU model-parallel + transformers 5.8 compat + Mistral-on-CPU data_process

### DIFF
--- a/diffsynth/diffusion/runner.py
+++ b/diffsynth/diffusion/runner.py
@@ -27,8 +27,17 @@ def launch_training_task(
     optimizer = torch.optim.AdamW(model.trainable_modules(), lr=learning_rate, weight_decay=weight_decay)
     scheduler = torch.optim.lr_scheduler.ConstantLR(optimizer)
     dataloader = torch.utils.data.DataLoader(dataset, shuffle=True, collate_fn=lambda x: x[0], num_workers=num_workers)
-    model.to(device=accelerator.device)
-    model, optimizer, dataloader, scheduler = accelerator.prepare(model, optimizer, dataloader, scheduler)
+    # Dual-GPU model-parallel: skip the device move that would undo our
+    # manual split, and tell accelerate not to touch the model's device.
+    _flux2_dual_gpu = os.environ.get("FLUX2_DUAL_GPU", "false").lower() == "true"
+    if not _flux2_dual_gpu:
+        model.to(device=accelerator.device)
+        model, optimizer, dataloader, scheduler = accelerator.prepare(model, optimizer, dataloader, scheduler)
+    else:
+        model, optimizer, dataloader, scheduler = accelerator.prepare(
+            model, optimizer, dataloader, scheduler,
+            device_placement=[False, True, True, True],
+        )
     initialize_deepspeed_gradient_checkpointing(accelerator)
     for epoch_id in range(num_epochs):
         for data in tqdm(dataloader):
@@ -59,8 +68,16 @@ def launch_data_process_task(
         num_workers = args.dataset_num_workers
         
     dataloader = torch.utils.data.DataLoader(dataset, shuffle=False, collate_fn=lambda x: x[0], num_workers=num_workers)
-    model.to(device=accelerator.device)
-    model, dataloader = accelerator.prepare(model, dataloader)
+    # Keep TE/VAE on CPU when explicitly requested. FLUX.2's Mistral-24B TE
+    # is ~48 GB bf16; data_process OOMs on cards <48 GB without CPU offload.
+    _data_process_on_cpu = os.environ.get('DIFFSYNTH_DATA_PROCESS_ON_CPU', 'false').lower() == 'true'
+    if not _data_process_on_cpu:
+        model.to(device=accelerator.device)
+        model, dataloader = accelerator.prepare(model, dataloader)
+    else:
+        model, dataloader = accelerator.prepare(
+            model, dataloader, device_placement=[False, True],
+        )
     
     for data_id, data in enumerate(tqdm(dataloader)):
         with accelerator.accumulate(model):

--- a/diffsynth/diffusion/runner.py
+++ b/diffsynth/diffusion/runner.py
@@ -29,8 +29,8 @@ def launch_training_task(
     dataloader = torch.utils.data.DataLoader(dataset, shuffle=True, collate_fn=lambda x: x[0], num_workers=num_workers)
     # Dual-GPU model-parallel: skip the device move that would undo our
     # manual split, and tell accelerate not to touch the model's device.
-    _flux2_dual_gpu = os.environ.get("FLUX2_DUAL_GPU", "false").lower() == "true"
-    if not _flux2_dual_gpu:
+    _diffsynth_dual_gpu = os.environ.get("DIFFSYNTH_DUAL_GPU", "false").lower() == "true"
+    if not _diffsynth_dual_gpu:
         model.to(device=accelerator.device)
         model, optimizer, dataloader, scheduler = accelerator.prepare(model, optimizer, dataloader, scheduler)
     else:

--- a/diffsynth/models/flux2_text_encoder.py
+++ b/diffsynth/models/flux2_text_encoder.py
@@ -54,5 +54,25 @@ class Flux2TextEncoder(Mistral3ForConditionalGeneration):
         super().__init__(config)
     
     def forward(self, input_ids = None, pixel_values = None, attention_mask = None, position_ids = None, past_key_values = None, inputs_embeds = None, labels = None, use_cache = None, output_attentions = None, output_hidden_states = None, return_dict = None, cache_position = None, logits_to_keep = 0, image_sizes = None, **kwargs):
-        return super().forward(input_ids, pixel_values, attention_mask, position_ids, past_key_values, inputs_embeds, labels, use_cache, output_attentions, output_hidden_states, return_dict, cache_position, logits_to_keep, image_sizes, **kwargs)
+        # transformers 5.8 trimmed Mistral3's positional args; pass everything
+        # as kwargs so the call survives across transformers versions. The dropped
+        # output_hidden_states / output_attentions are still honored via
+        # TransformersKwargs -> forward them through **kwargs.
+        if output_hidden_states is not None:
+            kwargs.setdefault("output_hidden_states", output_hidden_states)
+        if output_attentions is not None:
+            kwargs.setdefault("output_attentions", output_attentions)
+        return super().forward(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            labels=labels,
+            use_cache=use_cache,
+            logits_to_keep=logits_to_keep,
+            image_sizes=image_sizes,
+            **kwargs,
+        )
 

--- a/diffsynth/models/flux2_text_encoder.py
+++ b/diffsynth/models/flux2_text_encoder.py
@@ -55,13 +55,19 @@ class Flux2TextEncoder(Mistral3ForConditionalGeneration):
     
     def forward(self, input_ids = None, pixel_values = None, attention_mask = None, position_ids = None, past_key_values = None, inputs_embeds = None, labels = None, use_cache = None, output_attentions = None, output_hidden_states = None, return_dict = None, cache_position = None, logits_to_keep = 0, image_sizes = None, **kwargs):
         # transformers 5.8 trimmed Mistral3's positional args; pass everything
-        # as kwargs so the call survives across transformers versions. The dropped
-        # output_hidden_states / output_attentions are still honored via
-        # TransformersKwargs -> forward them through **kwargs.
+        # as kwargs so the call survives across transformers versions. Forward
+        # the four removed-from-positional args through **kwargs (transformers
+        # 5.8 honors output_hidden_states / output_attentions via
+        # TransformersKwargs; return_dict / cache_position are no-ops in 5.8
+        # but forwarded so older transformers versions still receive them).
         if output_hidden_states is not None:
             kwargs.setdefault("output_hidden_states", output_hidden_states)
         if output_attentions is not None:
             kwargs.setdefault("output_attentions", output_attentions)
+        if return_dict is not None:
+            kwargs.setdefault("return_dict", return_dict)
+        if cache_position is not None:
+            kwargs.setdefault("cache_position", cache_position)
         return super().forward(
             input_ids=input_ids,
             pixel_values=pixel_values,

--- a/examples/flux2/model_training/flux2_dual_gpu_diffsynth.py
+++ b/examples/flux2/model_training/flux2_dual_gpu_diffsynth.py
@@ -1,0 +1,173 @@
+"""Dual-GPU model-parallel for FLUX.2 in DiffSynth-Studio.
+
+Drop-in helper for DiffSynth-Studio
+(https://github.com/modelscope/DiffSynth-Studio) ``examples/flux2/model_training/``
+that splits the ``Flux2DiT`` transformer across two CUDA devices at the
+``single_transformer_blocks`` midpoint. Enables FLUX.2-dev LoRA training
+on pairs of 24+ GB consumer GPUs (2× RTX 3090, 2× RTX 4090, 2× RTX 5090)
+— on a single 24 GB card the FLUX.2 transformer can't fit alongside
+activations even with WDDM unified-memory paging.
+
+Companion to the validated ai-toolkit patch
+(https://github.com/genno-whittlery/flux2-dual-gpu-lora) and parallel
+ports for musubi-tuner, OneTrainer, and HuggingFace diffusers. The
+DiffSynth port is small because:
+
+- ``Flux2DiT`` is structurally identical to the diffusers
+  ``Flux2Transformer2DModel`` (same field names: ``x_embedder``,
+  ``context_embedder``, ``transformer_blocks``,
+  ``single_transformer_blocks``, ``norm_out``, ``proj_out``,
+  ``time_guidance_embed``, ``*_modulation*``, ``pos_embed``). The
+  identical helper structure transfers directly.
+- DiffSynth uses PEFT (``inject_adapter_in_model`` in
+  ``diffsynth.diffusion.training_module``) for LoRA injection, so
+  per-layer LoRA routing follows the base layer's device automatically.
+- The forward isn't overridden — pre-hooks bridge devices at the split
+  point and at ``norm_out`` (the boundary back to cuda:0).
+
+Env vars:
+    FLUX2_DUAL_GPU=true                    enable dual-GPU path
+    FLUX2_DUAL_GPU_SPLIT_AT=24             override split index
+                                           (default: num_single // 2)
+
+Usage in DiffSynth-Studio's training script
+(``examples/flux2/model_training/train.py``)::
+
+    from flux2_dual_gpu_diffsynth import enable_flux2_dual_gpu
+
+    # ...build pipeline / training module normally...
+    training_module = Flux2ImageTrainingModule(...)
+
+    # Activate the split (env-gated; no-op when FLUX2_DUAL_GPU is unset).
+    # Call AFTER LoRA injection (switch_pipe_to_training_mode) so PEFT
+    # has wrapped target modules. The split places the wrapped modules
+    # and PEFT LoRA params follow the base layer's device automatically.
+    enable_flux2_dual_gpu(training_module.pipe.dit)
+
+    # ...accelerator.prepare with device_placement=False for the
+    #    training_module, since the transformer is already distributed...
+
+Launch with ``--num_processes=1`` — this is *model* parallelism (both
+GPUs cooperate on a single training step), not data parallelism (which
+would spawn one process per GPU).
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+
+# ─── Env-gated public surface ───────────────────────────────────────────────
+
+def is_dual_gpu_enabled() -> bool:
+    """True iff ``FLUX2_DUAL_GPU=true`` in the environment."""
+    return os.getenv("FLUX2_DUAL_GPU", "false").lower() == "true"
+
+
+def get_split_at(num_single_blocks: int) -> int:
+    """Single-blocks split index. Override via ``FLUX2_DUAL_GPU_SPLIT_AT``."""
+    override = os.getenv("FLUX2_DUAL_GPU_SPLIT_AT")
+    if override is not None:
+        return int(override)
+    return num_single_blocks // 2
+
+
+def enable_flux2_dual_gpu(dit: nn.Module) -> nn.Module:
+    """Distribute the DiffSynth Flux2DiT across cuda:0 and cuda:1.
+
+    When ``FLUX2_DUAL_GPU`` is unset this is a no-op pass-through.
+
+    Call after the Flux2DiT (typically ``training_module.pipe.dit``) is
+    loaded and after any PEFT LoRA injection has run. PEFT places LoRA
+    params on the base layer's device automatically, so calling this
+    function after LoRA injection puts everything in the right place.
+
+    Returns the (in-place modified) dit.
+    """
+    if not is_dual_gpu_enabled():
+        return dit
+
+    if torch.cuda.device_count() < 2:
+        raise RuntimeError(
+            f"FLUX2_DUAL_GPU=true requires ≥2 CUDA devices, found "
+            f"{torch.cuda.device_count()}."
+        )
+
+    num_single = len(dit.single_transformer_blocks)
+    split_at = get_split_at(num_single)
+    if not 0 < split_at < num_single:
+        raise RuntimeError(
+            f"FLUX2_DUAL_GPU_SPLIT_AT={split_at} out of range "
+            f"(dit has {num_single} single blocks)."
+        )
+
+    cuda0 = torch.device("cuda:0")
+    cuda1 = torch.device("cuda:1")
+
+    # Place pre-blocks scaffolding + all double_blocks + first half of
+    # single_blocks on cuda:0. Output layers (norm_out + proj_out) stay
+    # on cuda:0 — the second pre-hook below brings the activation back
+    # from cuda:1 just in time for them.
+    dit.x_embedder.to(cuda0)
+    dit.context_embedder.to(cuda0)
+    dit.time_guidance_embed.to(cuda0)
+    dit.pos_embed.to(cuda0)
+    dit.double_stream_modulation_img.to(cuda0)
+    dit.double_stream_modulation_txt.to(cuda0)
+    dit.single_stream_modulation.to(cuda0)
+    for block in dit.transformer_blocks:
+        block.to(cuda0)
+    for block in dit.single_transformer_blocks[:split_at]:
+        block.to(cuda0)
+    for block in dit.single_transformer_blocks[split_at:]:
+        block.to(cuda1)
+    dit.norm_out.to(cuda0)
+    dit.proj_out.to(cuda0)
+
+    # Per-block hook on every cuda:1 single_block — the forward loop passes
+    # loop-level constants (temb_mod_params, image_rotary_emb,
+    # joint_attention_kwargs) to each block; a boundary-only hook bridges
+    # only the first block's inputs, so subsequent blocks receive the
+    # originals from cuda:0 and crash with a device-mismatch error.
+    for block in dit.single_transformer_blocks[split_at:]:
+        block.register_forward_pre_hook(
+            _make_device_bridge_hook(cuda1), with_kwargs=True
+        )
+    dit.norm_out.register_forward_pre_hook(
+        _make_device_bridge_hook(cuda0), with_kwargs=True
+    )
+
+    dit._flux2_dual_gpu_split_at = split_at
+    return dit
+
+
+# ─── Internals ──────────────────────────────────────────────────────────────
+
+def _move_to_device(obj: Any, device: torch.device) -> Any:
+    """Recursively move tensors in nested tuple/list/dict to ``device``.
+
+    No-op when a tensor is already on ``device`` (``Tensor.to`` is an
+    identity operation in that case).
+    """
+    if torch.is_tensor(obj):
+        return obj.to(device) if obj.device != device else obj
+    if isinstance(obj, tuple):
+        return tuple(_move_to_device(x, device) for x in obj)
+    if isinstance(obj, list):
+        return [_move_to_device(x, device) for x in obj]
+    if isinstance(obj, dict):
+        return {k: _move_to_device(v, device) for k, v in obj.items()}
+    return obj
+
+
+def _make_device_bridge_hook(target_device: torch.device):
+    """Forward pre-hook that moves all tensor inputs to ``target_device``."""
+    def hook(module, args, kwargs):
+        return (
+            _move_to_device(args, target_device),
+            _move_to_device(kwargs, target_device),
+        )
+    return hook

--- a/examples/flux2/model_training/flux2_dual_gpu_diffsynth.py
+++ b/examples/flux2/model_training/flux2_dual_gpu_diffsynth.py
@@ -26,8 +26,8 @@ DiffSynth port is small because:
   point and at ``norm_out`` (the boundary back to cuda:0).
 
 Env vars:
-    FLUX2_DUAL_GPU=true                    enable dual-GPU path
-    FLUX2_DUAL_GPU_SPLIT_AT=24             override split index
+    DIFFSYNTH_DUAL_GPU=true                    enable dual-GPU path
+    DIFFSYNTH_DUAL_GPU_SPLIT_AT=24             override split index
                                            (default: num_single // 2)
 
 Usage in DiffSynth-Studio's training script
@@ -38,7 +38,7 @@ Usage in DiffSynth-Studio's training script
     # ...build pipeline / training module normally...
     training_module = Flux2ImageTrainingModule(...)
 
-    # Activate the split (env-gated; no-op when FLUX2_DUAL_GPU is unset).
+    # Activate the split (env-gated; no-op when DIFFSYNTH_DUAL_GPU is unset).
     # Call AFTER LoRA injection (switch_pipe_to_training_mode) so PEFT
     # has wrapped target modules. The split places the wrapped modules
     # and PEFT LoRA params follow the base layer's device automatically.
@@ -63,13 +63,13 @@ import torch.nn as nn
 # ─── Env-gated public surface ───────────────────────────────────────────────
 
 def is_dual_gpu_enabled() -> bool:
-    """True iff ``FLUX2_DUAL_GPU=true`` in the environment."""
-    return os.getenv("FLUX2_DUAL_GPU", "false").lower() == "true"
+    """True iff ``DIFFSYNTH_DUAL_GPU=true`` in the environment."""
+    return os.getenv("DIFFSYNTH_DUAL_GPU", "false").lower() == "true"
 
 
 def get_split_at(num_single_blocks: int) -> int:
-    """Single-blocks split index. Override via ``FLUX2_DUAL_GPU_SPLIT_AT``."""
-    override = os.getenv("FLUX2_DUAL_GPU_SPLIT_AT")
+    """Single-blocks split index. Override via ``DIFFSYNTH_DUAL_GPU_SPLIT_AT``."""
+    override = os.getenv("DIFFSYNTH_DUAL_GPU_SPLIT_AT")
     if override is not None:
         return int(override)
     return num_single_blocks // 2
@@ -78,7 +78,7 @@ def get_split_at(num_single_blocks: int) -> int:
 def enable_flux2_dual_gpu(dit: nn.Module) -> nn.Module:
     """Distribute the DiffSynth Flux2DiT across cuda:0 and cuda:1.
 
-    When ``FLUX2_DUAL_GPU`` is unset this is a no-op pass-through.
+    When ``DIFFSYNTH_DUAL_GPU`` is unset this is a no-op pass-through.
 
     Call after the Flux2DiT (typically ``training_module.pipe.dit``) is
     loaded and after any PEFT LoRA injection has run. PEFT places LoRA
@@ -92,7 +92,7 @@ def enable_flux2_dual_gpu(dit: nn.Module) -> nn.Module:
 
     if torch.cuda.device_count() < 2:
         raise RuntimeError(
-            f"FLUX2_DUAL_GPU=true requires ≥2 CUDA devices, found "
+            f"DIFFSYNTH_DUAL_GPU=true requires ≥2 CUDA devices, found "
             f"{torch.cuda.device_count()}."
         )
 
@@ -100,7 +100,7 @@ def enable_flux2_dual_gpu(dit: nn.Module) -> nn.Module:
     split_at = get_split_at(num_single)
     if not 0 < split_at < num_single:
         raise RuntimeError(
-            f"FLUX2_DUAL_GPU_SPLIT_AT={split_at} out of range "
+            f"DIFFSYNTH_DUAL_GPU_SPLIT_AT={split_at} out of range "
             f"(dit has {num_single} single blocks)."
         )
 

--- a/examples/flux2/model_training/train.py
+++ b/examples/flux2/model_training/train.py
@@ -2,6 +2,7 @@ import torch, os, argparse, accelerate
 from diffsynth.core import UnifiedDataset
 from diffsynth.pipelines.flux2_image import Flux2ImagePipeline, ModelConfig
 from diffsynth.diffusion import *
+from flux2_dual_gpu_diffsynth import enable_flux2_dual_gpu, is_dual_gpu_enabled
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 
@@ -133,8 +134,41 @@ if __name__ == "__main__":
         template_model_id_or_path=args.template_model_id_or_path,
         enable_lora_hot_loading=args.enable_lora_hot_loading,
         task=args.task,
-        device="cpu" if args.initialize_model_on_cpu else accelerator.device,
+        # Dual-GPU: force CPU load so the 60 GB bf16 transformer doesn't
+        # pre-allocate on cuda:0 before we get a chance to split it.
+        device="cpu" if (args.initialize_model_on_cpu or is_dual_gpu_enabled()) else accelerator.device,
     )
+    # Dual-GPU split: gated on FLUX2_DUAL_GPU env var. Distributes
+    # pipe.dit across cuda:0 and cuda:1 at the single_transformer_blocks
+    # midpoint. Called AFTER LoRA injection (which happened inside
+    # Flux2ImageTrainingModule.__init__) so PEFT LoRA params follow
+    # the base layer's device automatically when block.to() runs.
+    if is_dual_gpu_enabled():
+        for _i in range(torch.cuda.device_count()):
+            _free, _total = torch.cuda.mem_get_info(_i)
+            print(f"[dual-gpu] pre-distribute cuda:{_i} free={_free/1024**3:.1f}G / {_total/1024**3:.1f}G")
+        # fp8 weight-only quant on CPU BEFORE distribute. Without this the
+        # bf16 transformer (~60 GB) overflows a 32 GB card on either side.
+        # Filter excludes LoRA's lora_A/lora_B Linear submodules -- quantizing
+        # them strips requires_grad and breaks backward.
+        import gc as _gc
+        from torchao.quantization import quantize_, Float8WeightOnlyConfig
+        def _quant_filter(module, name):
+            if not isinstance(module, torch.nn.Linear):
+                return False
+            return "lora_A" not in name and "lora_B" not in name
+        quantize_(model.pipe.dit, Float8WeightOnlyConfig(), filter_fn=_quant_filter)
+        _gc.collect()
+        print("[dual-gpu] fp8 weight-only quant done (LoRA params unmodified)")
+        enable_flux2_dual_gpu(model.pipe.dit)
+        # Pipeline tracks a logical device for input transfer (forward()
+        # calls transfer_data_to_device(inputs, pipe.device, ...)). Pin it
+        # to cuda:0 since x_embedder lives there.
+        model.pipe.device = torch.device("cuda:0")
+        for _i in range(torch.cuda.device_count()):
+            _free, _total = torch.cuda.mem_get_info(_i)
+            print(f"[dual-gpu] post-distribute cuda:{_i} free={_free/1024**3:.1f}G / {_total/1024**3:.1f}G")
+
     model_logger = ModelLogger(
         args.output_path,
         remove_prefix_in_ckpt=args.remove_prefix_in_ckpt,

--- a/examples/flux2/model_training/train.py
+++ b/examples/flux2/model_training/train.py
@@ -138,7 +138,7 @@ if __name__ == "__main__":
         # pre-allocate on cuda:0 before we get a chance to split it.
         device="cpu" if (args.initialize_model_on_cpu or is_dual_gpu_enabled()) else accelerator.device,
     )
-    # Dual-GPU split: gated on FLUX2_DUAL_GPU env var. Distributes
+    # Dual-GPU split: gated on DIFFSYNTH_DUAL_GPU env var. Distributes
     # pipe.dit across cuda:0 and cuda:1 at the single_transformer_blocks
     # midpoint. Called AFTER LoRA injection (which happened inside
     # Flux2ImageTrainingModule.__init__) so PEFT LoRA params follow


### PR DESCRIPTION
## Summary

Three independent improvements to `examples/flux2/model_training/` and the underlying flux2 pipeline. All three are gated on environment variables / option flags so single-GPU users see no behavior change unless they opt in.

1. **Dual-GPU model-parallel** for FLUX.2 LoRA training (`DIFFSYNTH_DUAL_GPU=true`).
2. **Mistral-on-CPU mode** for `sft:data_process` (`DIFFSYNTH_DATA_PROCESS_ON_CPU=true`), so cards without 48+ GB VRAM can still produce the feature cache.
3. **`transformers` 5.8 compatibility** for `Flux2TextEncoder.forward` (independent fix, single-GPU users benefit too).

## Hardware target (why this matters most for 24 GB users)

The FLUX.2 transformer is ~60 GB in bf16. The bulk of the consumer-GPU population (24 GB cards: RTX 3090, RTX 4090, RTX A5000) cannot fit it on a single card even with fp8 weight-only quant + activation offload. RTX 5090 (32 GB) handles the single-card recipe, but supply is constrained and prices remain well above MSRP — most users who *can* train FLUX.2 LoRAs do so on the 24 GB stack.

| GPU class | Single-card FLUX.2 LoRA | Dual-GPU (this PR) |
|---|---|---|
| 1× 32 GB (5090) | Fits with fp8 weight-only + gradient checkpointing; ~26-29 GB peak. Validated. | Validated: 20.7 GB cuda:0 / 12.6 GB cuda:1 at 2.69 s/it. |
| 1× 24 GB (3090 / 4090) | Doesn't fit even with all the low-VRAM tricks — fp8 weights alone are ~30 GB. | 2× 24 GB: ~21 GB cuda:0 + ~13 GB cuda:1 — comfortable headroom. |
| 1× 16 GB or below | Doesn't fit. | 2× 16 GB: would need fp8 on both halves; architecturally fine, not validated yet. |

So this isn't really about "faster than the single-card path" — it's about **making FLUX.2 LoRA training reachable from the 2×-24-GB market at all**, which is where the consumer 2-GPU configurations actually live (used 3090s, second-gen 4090 builds, A5000 workstations).

## What changed

### Dual-GPU FLUX.2 LoRA training

- `examples/flux2/model_training/flux2_dual_gpu_diffsynth.py` (new, ~170 LOC): splits `Flux2DiT.single_transformer_blocks` at the midpoint across `cuda:0`/`cuda:1`. Registers `forward_pre_hook` on **every** cuda:1 single block — `Flux2DiT.forward` passes loop-level constants (`temb_mod_params`, `image_rotary_emb`, `joint_attention_kwargs`) to each iteration, so a boundary-only hook would leave subsequent blocks receiving cuda:0 tensors.

- `examples/flux2/model_training/train.py`: forces CPU model load when `DIFFSYNTH_DUAL_GPU=true` (the ~60 GB bf16 transformer would otherwise pre-allocate on cuda:0 before split), runs `torchao.quantize_` with `Float8WeightOnlyConfig` + a `filter_fn` that excludes `lora_A` / `lora_B` Linear submodules (otherwise their `requires_grad` is stripped and backward fails at the loss), then calls `enable_flux2_dual_gpu(model.pipe.dit)` *after* PEFT has injected LoRA so `block.to(device)` carries LoRA params with their base layers.

- `diffsynth/diffusion/runner.py` (`launch_training_task`): skips `model.to(accelerator.device)` and uses `device_placement=[False, True, True, True]` in `accelerator.prepare` when `DIFFSYNTH_DUAL_GPU=true`. The env var name is intentionally model-neutral (per @gemini-code-assist review on #1436) so the same gate covers both FLUX.2 and Wan dual-GPU paths.

### Mistral-on-CPU `sft:data_process`

- `diffsynth/diffusion/runner.py` (`launch_data_process_task`): env-var-gated CPU-offload branch (`DIFFSYNTH_DATA_PROCESS_ON_CPU=true`). Combined with `--initialize_model_on_cpu`, this lets users on cards without 48 GB VRAM run the feature-cache step on CPU (~15 s per 256-token caption at 512² — slow, but a one-time pre-process). Without this, Mistral-3-Small-24B's ~48 GB bf16 weights OOM on any consumer 32 GB card.

### transformers 5.8 compat

`transformers` 5.8 trimmed `Mistral3ForConditionalGeneration.forward`'s positional signature (removed `output_attentions`, `output_hidden_states`, `return_dict`, `cache_position` — they're `TransformersKwargs`-only now). The existing wrapper passed 15 positional args and dies with:

```
TypeError: Mistral3ForConditionalGeneration.forward() takes from 1 to 11
positional arguments but 15 were given
```

Rewrote `Flux2TextEncoder.forward` to pass everything by keyword and re-inject `output_hidden_states` / `output_attentions` via `**kwargs` so the existing `get_mistral_3_small_prompt_embeds` caller still receives a populated `output.hidden_states`.

## Validation

End-to-end on 2× RTX 5090 with sumi v8 data + the unchanged recipe from `examples/flux2/model_training/lora/FLUX.2-dev.sh`:

- `sft:data_process` (with `--initialize_model_on_cpu` + `DIFFSYNTH_DATA_PROCESS_ON_CPU=true`): 3 sumi-v8 images cached on CPU-offloaded Mistral-24B in **43 s**.
- `sft:train` (with `DIFFSYNTH_DUAL_GPU=true`): **15/15 steps at 2.69 s/it sustained**, 40 s wall-clock. Distribution lands at 20.7 GB cuda:0 / 12.6 GB cuda:1 after fp8 weight-only quant. LoRA checkpoint (270 MB at rank 32) saved.

Cross-vendor (2× 3090 / 2× 4090) validation pending — happy to run if a maintainer has access to those configs and wants concrete numbers before merge. Architecture math suggests comfortable fit; the patch shape has been validated across four FLUX.2 LoRA trainers (ai-toolkit, musubi-tuner, OneTrainer, DiffSynth-Studio) with consistent ~21 / ~13 GB distribution.

## Context

Cross-trainer write-up at https://github.com/genno-whittlery/flux2-dual-gpu-lora; DiffSynth-specific porting walkthrough at https://github.com/genno-whittlery/flux2-dual-gpu-lora/blob/main/docs/porting-diffsynth-studio.md.

The LoRA-skip `filter_fn` on `quantize_` was a novel finding from this port — diffusers' reference script earlier hit `TorchaoLoraLinear`'s constructor incompatibility because it was quantizing LoRA submodules too. Skipping `lora_A` / `lora_B` keeps `requires_grad` and routes PEFT through its normal `LoraLinear` instead of the broken torchao dispatcher.

Companion PR #1436 ports the same dual-GPU pattern to Wan video LoRA training and shares the `DIFFSYNTH_DUAL_GPU` env var with this PR.

## Test plan
- [x] `sft:data_process` on 2× RTX 5090 with Mistral-on-CPU — produces valid cached .pth files (verified shapes: latents (1,1024,128) bf16, prompt_embeds (1,512,15360) bf16)
- [x] `sft:train` 15-step run, dual-GPU, fp8 weight-only — completes, LoRA saves
- [x] `transformers` 5.8 — Mistral3 forward succeeds, `output.hidden_states` populated for `get_mistral_3_small_prompt_embeds`
- [x] single-GPU path unchanged (env vars unset → `train.py` / `runner.py` take existing branches)
- [ ] 2× 24 GB validation (3090 / 4090) — pending; happy to run if a reviewer has hardware
- [ ] downstream tasks (Wan 2.2 etc.) regression-tested — not yet run; this PR only touches `flux2` examples + `flux2_text_encoder.py` + `runner.py` (gated branches only)
