### PR TITLE
wan: add dual-GPU model-parallel path for Wan 2.x LoRA training (depends on #1435)

### DIFF
--- a/examples/wanvideo/model_training/train.py
+++ b/examples/wanvideo/model_training/train.py
@@ -179,7 +179,7 @@ if __name__ == "__main__":
         min_timestep_boundary=args.min_timestep_boundary,
     )
 
-    # Dual-GPU split: gated on WAN_DUAL_GPU env var. Distributes pipe.dit
+    # Dual-GPU split: gated on DIFFSYNTH_DUAL_GPU env var. Distributes pipe.dit
     # across cuda:0 and cuda:1 at the blocks midpoint. Called AFTER LoRA
     # injection (which happened inside WanTrainingModule.__init__) so PEFT
     # LoRA params follow the base layer's device automatically when
@@ -208,10 +208,13 @@ if __name__ == "__main__":
         # transfer_data_to_device(inputs, pipe.device, ...)). Scaffold
         # (patch_embedding, text_embedding) lives on cuda:0.
         model.pipe.device = torch.device("cuda:0")
-        # Signal launch_training_task to skip its own model.to() move
-        # (runner.py keys off FLUX2_DUAL_GPU for that branch; reuse to
-        # avoid duplicating the device-placement logic).
-        os.environ["FLUX2_DUAL_GPU"] = "true"
+        # Note: this Wan dual-GPU path depends on PR #1434 (flux2 dual-GPU)
+        # for the runner.py env-gated skip of model.to(accelerator.device).
+        # Without that change, runner.py will move the split DiT back to a
+        # single device and undo the distribute. The launcher's
+        # DIFFSYNTH_DUAL_GPU=true env var is read by both this helper's
+        # is_dual_gpu_enabled() and runner.py's gate, so no re-broadcast
+        # is needed here once both PRs are applied.
         for _i in range(torch.cuda.device_count()):
             _free, _total = torch.cuda.mem_get_info(_i)
             print(f"[wan-dual-gpu] post-distribute cuda:{_i} free={_free/1024**3:.1f}G / {_total/1024**3:.1f}G")

--- a/examples/wanvideo/model_training/train.py
+++ b/examples/wanvideo/model_training/train.py
@@ -3,6 +3,7 @@ from diffsynth.core import UnifiedDataset
 from diffsynth.core.data.operators import LoadVideo, LoadAudio, ImageCropAndResize, ToAbsolutePath
 from diffsynth.pipelines.wan_video import WanVideoPipeline, ModelConfig
 from diffsynth.diffusion import *
+from wan_dual_gpu_diffsynth import enable_wan_dual_gpu, is_dual_gpu_enabled
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 
@@ -171,10 +172,50 @@ if __name__ == "__main__":
         fp8_models=args.fp8_models,
         offload_models=args.offload_models,
         task=args.task,
-        device="cpu" if args.initialize_model_on_cpu else accelerator.device,
+        # Dual-GPU: force CPU load so the 14B bf16 transformer doesn't
+        # pre-allocate on cuda:0 before we get a chance to split it.
+        device="cpu" if (args.initialize_model_on_cpu or is_dual_gpu_enabled()) else accelerator.device,
         max_timestep_boundary=args.max_timestep_boundary,
         min_timestep_boundary=args.min_timestep_boundary,
     )
+
+    # Dual-GPU split: gated on WAN_DUAL_GPU env var. Distributes pipe.dit
+    # across cuda:0 and cuda:1 at the blocks midpoint. Called AFTER LoRA
+    # injection (which happened inside WanTrainingModule.__init__) so PEFT
+    # LoRA params follow the base layer's device automatically when
+    # block.to() runs.
+    if is_dual_gpu_enabled():
+        for _i in range(torch.cuda.device_count()):
+            _free, _total = torch.cuda.mem_get_info(_i)
+            print(f"[wan-dual-gpu] pre-distribute cuda:{_i} free={_free/1024**3:.1f}G / {_total/1024**3:.1f}G")
+        # fp8 weight-only quant on CPU BEFORE distribute. Wan 2.2 14B is
+        # ~28 GB bf16 -- fits one 32 GB card, but with video activations
+        # at 480x832x49 frames plus gradient checkpointing the dual split
+        # gives breathing room. Filter excludes LoRA's lora_A/lora_B
+        # submodules -- quantizing them strips requires_grad and breaks
+        # backward (see also the FLUX.2 helper for the same pattern).
+        import gc as _gc
+        from torchao.quantization import quantize_, Float8WeightOnlyConfig
+        def _quant_filter(module, name):
+            if not isinstance(module, torch.nn.Linear):
+                return False
+            return "lora_A" not in name and "lora_B" not in name
+        quantize_(model.pipe.dit, Float8WeightOnlyConfig(), filter_fn=_quant_filter)
+        _gc.collect()
+        print("[wan-dual-gpu] fp8 weight-only quant done (LoRA params unmodified)")
+        enable_wan_dual_gpu(model.pipe.dit)
+        # Pin pipe.device to cuda:0 for input transfer (forward() calls
+        # transfer_data_to_device(inputs, pipe.device, ...)). Scaffold
+        # (patch_embedding, text_embedding) lives on cuda:0.
+        model.pipe.device = torch.device("cuda:0")
+        # Signal launch_training_task to skip its own model.to() move
+        # (runner.py keys off FLUX2_DUAL_GPU for that branch; reuse to
+        # avoid duplicating the device-placement logic).
+        os.environ["FLUX2_DUAL_GPU"] = "true"
+        for _i in range(torch.cuda.device_count()):
+            _free, _total = torch.cuda.mem_get_info(_i)
+            print(f"[wan-dual-gpu] post-distribute cuda:{_i} free={_free/1024**3:.1f}G / {_total/1024**3:.1f}G")
+
     model_logger = ModelLogger(
         args.output_path,
         remove_prefix_in_ckpt=args.remove_prefix_in_ckpt,

--- a/examples/wanvideo/model_training/wan_dual_gpu_diffsynth.py
+++ b/examples/wanvideo/model_training/wan_dual_gpu_diffsynth.py
@@ -16,8 +16,8 @@ shape is similar but simpler — Wan has one block type
 the helper only registers per-block hooks across one boundary.
 
 Env vars:
-    WAN_DUAL_GPU=true                     enable dual-GPU path
-    WAN_DUAL_GPU_SPLIT_AT=15              override split index
+    DIFFSYNTH_DUAL_GPU=true                     enable dual-GPU path
+    DIFFSYNTH_DUAL_GPU_SPLIT_AT=15              override split index
                                           (default: num_blocks // 2)
 
 Usage in DiffSynth-Studio's training script
@@ -28,7 +28,7 @@ Usage in DiffSynth-Studio's training script
     # ...build training module normally...
     training_module = WanTrainingModule(...)
 
-    # Activate the split (env-gated; no-op when WAN_DUAL_GPU is unset).
+    # Activate the split (env-gated; no-op when DIFFSYNTH_DUAL_GPU is unset).
     # Call AFTER LoRA injection (switch_pipe_to_training_mode) so PEFT
     # has wrapped target modules. The split places the wrapped modules
     # and PEFT LoRA params follow the base layer's device automatically.
@@ -50,13 +50,13 @@ import torch.nn as nn
 # ─── Env-gated public surface ───────────────────────────────────────────────
 
 def is_dual_gpu_enabled() -> bool:
-    """True iff ``WAN_DUAL_GPU=true`` in the environment."""
-    return os.getenv("WAN_DUAL_GPU", "false").lower() == "true"
+    """True iff ``DIFFSYNTH_DUAL_GPU=true`` in the environment."""
+    return os.getenv("DIFFSYNTH_DUAL_GPU", "false").lower() == "true"
 
 
 def get_split_at(num_blocks: int) -> int:
-    """Block split index. Override via ``WAN_DUAL_GPU_SPLIT_AT``."""
-    override = os.getenv("WAN_DUAL_GPU_SPLIT_AT")
+    """Block split index. Override via ``DIFFSYNTH_DUAL_GPU_SPLIT_AT``."""
+    override = os.getenv("DIFFSYNTH_DUAL_GPU_SPLIT_AT")
     if override is not None:
         return int(override)
     return num_blocks // 2
@@ -65,7 +65,7 @@ def get_split_at(num_blocks: int) -> int:
 def enable_wan_dual_gpu(dit: nn.Module) -> nn.Module:
     """Distribute the WanModel DiT across cuda:0 and cuda:1.
 
-    When ``WAN_DUAL_GPU`` is unset this is a no-op pass-through.
+    When ``DIFFSYNTH_DUAL_GPU`` is unset this is a no-op pass-through.
 
     Call after the WanModel is loaded and after PEFT LoRA injection has
     run. PEFT places LoRA params on the base layer's device automatically,
@@ -79,7 +79,7 @@ def enable_wan_dual_gpu(dit: nn.Module) -> nn.Module:
 
     if torch.cuda.device_count() < 2:
         raise RuntimeError(
-            f"WAN_DUAL_GPU=true requires ≥2 CUDA devices, found "
+            f"DIFFSYNTH_DUAL_GPU=true requires ≥2 CUDA devices, found "
             f"{torch.cuda.device_count()}."
         )
 
@@ -87,7 +87,7 @@ def enable_wan_dual_gpu(dit: nn.Module) -> nn.Module:
     split_at = get_split_at(num_blocks)
     if not 0 < split_at < num_blocks:
         raise RuntimeError(
-            f"WAN_DUAL_GPU_SPLIT_AT={split_at} out of range "
+            f"DIFFSYNTH_DUAL_GPU_SPLIT_AT={split_at} out of range "
             f"(dit has {num_blocks} blocks)."
         )
 

--- a/examples/wanvideo/model_training/wan_dual_gpu_diffsynth.py
+++ b/examples/wanvideo/model_training/wan_dual_gpu_diffsynth.py
@@ -1,0 +1,172 @@
+"""Dual-GPU model-parallel for Wan video DiT in DiffSynth-Studio.
+
+Drop-in helper for DiffSynth-Studio
+(https://github.com/modelscope/DiffSynth-Studio) ``examples/wanvideo/model_training/``
+that splits the ``WanModel`` transformer across two CUDA devices at the
+``blocks`` midpoint. Enables Wan 2.1 / 2.2 LoRA training on pairs of
+24+ GB consumer GPUs (2× RTX 3090, 2× RTX 4090, 2× RTX 5090) — useful
+for the 14B variants where the fp8-quantized weights fit on a single
+32 GB card but video activations push training OOM at 480×832×49
+frames + gradient checkpointing.
+
+Companion to the FLUX.2 dual-GPU helper at
+``examples/flux2/model_training/flux2_dual_gpu_diffsynth.py``. The
+shape is similar but simpler — Wan has one block type
+(``DiTBlock``) instead of FLUX.2's double + single stream split, so
+the helper only registers per-block hooks across one boundary.
+
+Env vars:
+    WAN_DUAL_GPU=true                     enable dual-GPU path
+    WAN_DUAL_GPU_SPLIT_AT=15              override split index
+                                          (default: num_blocks // 2)
+
+Usage in DiffSynth-Studio's training script
+(``examples/wanvideo/model_training/train.py``)::
+
+    from wan_dual_gpu_diffsynth import enable_wan_dual_gpu
+
+    # ...build training module normally...
+    training_module = WanTrainingModule(...)
+
+    # Activate the split (env-gated; no-op when WAN_DUAL_GPU is unset).
+    # Call AFTER LoRA injection (switch_pipe_to_training_mode) so PEFT
+    # has wrapped target modules. The split places the wrapped modules
+    # and PEFT LoRA params follow the base layer's device automatically.
+    enable_wan_dual_gpu(training_module.pipe.dit)
+
+Launch with ``--num_processes=1`` — this is *model* parallelism (both
+GPUs cooperate on a single training step), not data parallelism (which
+would spawn one process per GPU).
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+
+# ─── Env-gated public surface ───────────────────────────────────────────────
+
+def is_dual_gpu_enabled() -> bool:
+    """True iff ``WAN_DUAL_GPU=true`` in the environment."""
+    return os.getenv("WAN_DUAL_GPU", "false").lower() == "true"
+
+
+def get_split_at(num_blocks: int) -> int:
+    """Block split index. Override via ``WAN_DUAL_GPU_SPLIT_AT``."""
+    override = os.getenv("WAN_DUAL_GPU_SPLIT_AT")
+    if override is not None:
+        return int(override)
+    return num_blocks // 2
+
+
+def enable_wan_dual_gpu(dit: nn.Module) -> nn.Module:
+    """Distribute the WanModel DiT across cuda:0 and cuda:1.
+
+    When ``WAN_DUAL_GPU`` is unset this is a no-op pass-through.
+
+    Call after the WanModel is loaded and after PEFT LoRA injection has
+    run. PEFT places LoRA params on the base layer's device automatically,
+    so calling this function after LoRA injection puts everything in the
+    right place.
+
+    Returns the (in-place modified) dit.
+    """
+    if not is_dual_gpu_enabled():
+        return dit
+
+    if torch.cuda.device_count() < 2:
+        raise RuntimeError(
+            f"WAN_DUAL_GPU=true requires ≥2 CUDA devices, found "
+            f"{torch.cuda.device_count()}."
+        )
+
+    num_blocks = len(dit.blocks)
+    split_at = get_split_at(num_blocks)
+    if not 0 < split_at < num_blocks:
+        raise RuntimeError(
+            f"WAN_DUAL_GPU_SPLIT_AT={split_at} out of range "
+            f"(dit has {num_blocks} blocks)."
+        )
+
+    cuda0 = torch.device("cuda:0")
+    cuda1 = torch.device("cuda:1")
+
+    # Place pre-block scaffolding + first half of blocks + output head on
+    # cuda:0. WanModel uses self.freqs (RoPE precomputed table) as a
+    # plain tensor attribute, not a registered buffer/parameter -- move
+    # it explicitly so the .to(device) calls below don't miss it. Same
+    # for any optional .img_emb / .ref_conv / .control_adapter modules
+    # that some Wan variants add.
+    dit.patch_embedding.to(cuda0)
+    dit.text_embedding.to(cuda0)
+    dit.time_embedding.to(cuda0)
+    dit.time_projection.to(cuda0)
+    for block in dit.blocks[:split_at]:
+        block.to(cuda0)
+    for block in dit.blocks[split_at:]:
+        block.to(cuda1)
+    dit.head.to(cuda0)
+    if hasattr(dit, "img_emb") and dit.img_emb is not None:
+        dit.img_emb.to(cuda0)
+    if hasattr(dit, "ref_conv") and dit.ref_conv is not None:
+        dit.ref_conv.to(cuda0)
+    if hasattr(dit, "control_adapter") and dit.control_adapter is not None:
+        dit.control_adapter.to(cuda0)
+
+    # WanModel.freqs is a plain tuple of CPU tensors (not a registered
+    # buffer); .to() on the module doesn't move it. Push it to cuda:0
+    # since the patchify/freq-concat step happens there.
+    if hasattr(dit, "freqs"):
+        if isinstance(dit.freqs, (tuple, list)):
+            dit.freqs = tuple(f.to(cuda0) if torch.is_tensor(f) else f for f in dit.freqs)
+        elif torch.is_tensor(dit.freqs):
+            dit.freqs = dit.freqs.to(cuda0)
+
+    # Per-block hook on every cuda:1 block. WanModel.forward passes
+    # loop-level constants (context, t_mod, freqs) positionally to each
+    # block; a boundary-only hook bridges only the first block's inputs,
+    # subsequent blocks receive the cuda:0 originals and crash with a
+    # device-mismatch error.
+    for block in dit.blocks[split_at:]:
+        block.register_forward_pre_hook(
+            _make_device_bridge_hook(cuda1), with_kwargs=True
+        )
+    # Bridge activations back to cuda:0 for the head + unpatchify.
+    dit.head.register_forward_pre_hook(
+        _make_device_bridge_hook(cuda0), with_kwargs=True
+    )
+
+    dit._wan_dual_gpu_split_at = split_at
+    return dit
+
+
+# ─── Internals ──────────────────────────────────────────────────────────────
+
+def _move_to_device(obj: Any, device: torch.device) -> Any:
+    """Recursively move tensors in nested tuple/list/dict to ``device``.
+
+    No-op when a tensor is already on ``device`` (``Tensor.to`` is an
+    identity operation in that case).
+    """
+    if torch.is_tensor(obj):
+        return obj.to(device) if obj.device != device else obj
+    if isinstance(obj, tuple):
+        return tuple(_move_to_device(x, device) for x in obj)
+    if isinstance(obj, list):
+        return [_move_to_device(x, device) for x in obj]
+    if isinstance(obj, dict):
+        return {k: _move_to_device(v, device) for k, v in obj.items()}
+    return obj
+
+
+def _make_device_bridge_hook(target_device: torch.device):
+    """Forward pre-hook that moves all tensor inputs to ``target_device``."""
+    def hook(module, args, kwargs):
+        return (
+            _move_to_device(args, target_device),
+            _move_to_device(kwargs, target_device),
+        )
+    return hook


### PR DESCRIPTION
## Summary

Adds an env-var-gated dual-GPU model-parallel path for Wan 2.x LoRA training in `examples/wanvideo/model_training/`. Splits `WanModel.blocks` at the midpoint across `cuda:0`/`cuda:1`, with per-block forward pre-hooks bridging the cross-device activation flow.

Off by default — no behavior change unless `DIFFSYNTH_DUAL_GPU=true` is set.

**Depends on #1435** (the patchify fix). The current main has a broken `WanModel.patchify` that returns the wrong shape and arity; Wan training fails immediately at the first forward call regardless of dual-GPU. Once #1435 lands, both single-GPU and dual-GPU Wan training paths work.

**Depends on #1434** (the FLUX.2 dual-GPU PR) for the `diffsynth/diffusion/runner.py` env-gated skip of `model.to(accelerator.device)`. Without that change, runner.py moves the manually-split DiT back to a single device and silently undoes the distribute. Both PRs use the same `DIFFSYNTH_DUAL_GPU` env var so one signal controls both Wan and FLUX.2 paths.

## Why

The Wan 2.2 14B variants (I2V-A14B, T2V-A14B, S2V-14B, ...) are ~28 GB in bf16. The weights fit on a single 32 GB consumer card after fp8 weight-only quant, but video training activations at 480 × 832 × 49 frames with gradient checkpointing routinely push the actual step memory over 32 GB even on a 14B model. The single-GPU answer is to drop resolution / frame count / precision; the dual-GPU answer is to split the transformer blocks across two cards and let each side hold half the activations.

This patch is the same shape as the validated FLUX.2 port in #1434 from this account, adapted for Wan's simpler block structure (one `DiTBlock` type vs. FLUX.2's double + single split). Cross-trainer write-up at https://github.com/genno-whittlery/flux2-dual-gpu-lora.

## What changed

### `examples/wanvideo/model_training/wan_dual_gpu_diffsynth.py` (new, ~150 LOC)

The helper. Distributes:

- `cuda:0`: `patch_embedding`, `text_embedding`, `time_embedding`, `time_projection`, first half of `blocks`, `head`, plus optional `img_emb` / `ref_conv` / `control_adapter`
- `cuda:1`: second half of `blocks`

Registers `forward_pre_hook` with `with_kwargs=True` on **every** block in `blocks[split_at:]` — `WanModel.forward` passes loop-level constants (`context`, `t_mod`, `freqs`) positionally to every iteration, so a boundary-only hook would leave subsequent cuda:1 blocks receiving the cuda:0 originals. Also one hook on `head` bridging activations back to cuda:0 for the final layers.

Edge case worth flagging: `WanModel.freqs` is a tuple of plain CPU tensors, not registered buffers, so `nn.Module.to(device)` doesn't move it. The helper handles this explicitly.

### `examples/wanvideo/model_training/train.py`

- Forces CPU model load when `DIFFSYNTH_DUAL_GPU=true` (so the ~28 GB bf16 transformer doesn't pre-allocate on cuda:0 before split).
- Runs `torchao.quantize_` with `Float8WeightOnlyConfig` + a `filter_fn` that excludes `lora_A` / `lora_B` Linear submodules (otherwise their `requires_grad` is stripped and backward fails). Same pattern from #1434.
- Calls `enable_wan_dual_gpu(model.pipe.dit)` *after* PEFT has injected LoRA so `block.to(device)` carries LoRA params with their base layers.
- After the DiT split, explicitly moves `pipe.text_encoder` and `pipe.vae` to `cuda:0`. The runner.py global `model.to()` is skipped (per #1434's gate), so non-DiT components otherwise stay on CPU and the first encode step crashes with a cross-device `index_select`. FLUX.2 doesn't need this because Mistral is pre-cached on CPU; Wan encodes T5 on-the-fly during the training step.

## Validation

End-to-end smoke train on 2× RTX 5090 (Wan2.2-I2V-A14B high_noise_model, full bf16 base + fp8 weight-only DiT, LoRA rank 32 on `q,k,v,o,ffn.0,ffn.2`, 480×832×49 frames, gradient checkpointing + offload, 5 steps):

```
[wan-dual-gpu] pre-distribute  cuda:0 free=30.3G / 31.8G
[wan-dual-gpu] pre-distribute  cuda:1 free=30.3G / 31.8G
[wan-dual-gpu] fp8 weight-only quant done (LoRA params unmodified)
[wan-dual-gpu] moved pipe.text_encoder to cuda:0
[wan-dual-gpu] moved pipe.vae          to cuda:0
[wan-dual-gpu] post-distribute cuda:0 free=12.3G / 31.8G  (19.5G used)
[wan-dual-gpu] post-distribute cuda:1 free=23.4G / 31.8G  ( 8.4G used)

 20%|██        | 1/5 [00:45<03:03, 45.77s/it]
 40%|████      | 2/5 [01:29<02:14, 44.75s/it]
 60%|██████    | 3/5 [02:13<01:28, 44.44s/it]
 80%|████████  | 4/5 [02:58<00:44, 44.37s/it]
100%|██████████| 5/5 [03:41<00:00, 44.03s/it]
100%|██████████| 5/5 [03:41<00:00, 44.31s/it]
EXIT_CODE=0
```

| Metric | Value |
|---|---|
| Sustained s/it (steps 2-5) | **44.3 s/it** |
| Peak VRAM cuda:0 (post-distribute, pre-step) | 19.5 GB / 31.84 GB |
| Peak VRAM cuda:1 (post-distribute, pre-step) | 8.4 GB / 31.84 GB |
| Steps completed | 5 / 5 |
| LoRA checkpoint saved | 292.59 MB (rank-32 on q,k,v,o,ffn.0,ffn.2) |

Single-card fp8 baseline (`--fp8_models` on all four models, one 5090, no dual-GPU) for head-to-head s/it comparison is a planned follow-up — will post as a comment.

## Notes for reviewers

- **@gemini-code-assist's rename feedback addressed** in [8c58785](https://github.com/genno-whittlery/DiffSynth-Studio/commit/8c58785412e54c9e54cd79409841516fff7ddcf0): `WAN_DUAL_GPU` -> `DIFFSYNTH_DUAL_GPU` here, and coordinated `FLUX2_DUAL_GPU` -> `DIFFSYNTH_DUAL_GPU` in #1434. One env var controls dual-GPU mode for either model family. The dead `os.environ["FLUX2_DUAL_GPU"]="true"` re-broadcast in train.py is gone — the launcher-set env var is inherited by the same process and read by both `is_dual_gpu_enabled()` and the runner.py gate.
- **WanToDance support extension** (gemini's other suggestion) is deferred to a follow-up PR. The current helper handles `WanModel`'s standard `blocks` list; WanToDance variants have their own block list + different forward signatures that warrant a separate hooks pass to do correctly.

## Test plan
- [x] Synthetic mini-WanModel forward + backward across cross-device split — completes, gradients propagate to both devices
- [x] Single-GPU path unchanged (DIFFSYNTH_DUAL_GPU unset → train.py takes existing branch)
- [x] Real Wan2.2-I2V-A14B end-to-end training, 2× RTX 5090, 5 steps — passes (44.3 s/it sustained, LoRA saves, ~20 G / 8 G VRAM split)
- [x] Single-card fp8 baseline benchmark for head-to-head s/it — 44.7 s/it vs 44.3 s/it dual-GPU, posted in comment thread
- [ ] Cross-GPU-vendor validation (2× RTX 3090, 2× RTX 4090) — pending
