### PR TITLE
feat: add bmp extension support to default_video_operator

### DIFF
--- a/diffsynth/core/data/unified_dataset.py
+++ b/diffsynth/core/data/unified_dataset.py
@@ -46,7 +46,7 @@ class UnifiedDataset(torch.utils.data.Dataset):
     ):
         return RouteByType(operator_map=[
             (str, ToAbsolutePath(base_path) >> RouteByExtensionName(operator_map=[
-                (("jpg", "jpeg", "png", "webp"), LoadImage() >> ImageCropAndResize(height, width, max_pixels, height_division_factor, width_division_factor) >> ToList()),
+                (("jpg", "jpeg", "png", "webp", "bmp"), LoadImage() >> ImageCropAndResize(height, width, max_pixels, height_division_factor, width_division_factor) >> ToList()),
                 (("gif",), LoadGIF(
                     num_frames, time_division_factor, time_division_remainder,
                     frame_processor=ImageCropAndResize(height, width, max_pixels, height_division_factor, width_division_factor),


### PR DESCRIPTION
## Summary
- Adds `bmp` to the supported image extensions in `UnifiedDataset.default_video_operator` so that BMP image datasets can be used for training/processing alongside JPG/PNG/WebP.

## Motivation
Issue #1456 reports that BMP files are not accepted by the dataset loader even though `LoadImage` (PIL-backed) handles them natively. The fix is to include `"bmp"` in the extension tuple routed to the `LoadImage >> ImageCropAndResize >> ToList` pipeline — identical behavior to the other still-image formats.

Closes #1456

## Test plan
- [x] Code compiles / imports unchanged
- [x] Verified that PIL's `Image.open` already supports `.bmp`, so `LoadImage` does not need any change
- [ ] Reviewer can confirm by training with a BMP dataset