### PR TITLE
feat: support wandb project env

### DIFF
--- a/diffsynth/diffusion/logger.py
+++ b/diffsynth/diffusion/logger.py
@@ -33,6 +33,7 @@ class SwanLabLogger:
 class WandbLogger:
     def __init__(self, project_name="DiffSynth-Studio", log_dir=None):
         import wandb
+        project_name = os.environ.get("WANDB_PROJECT", project_name)
         self.wandb = wandb
         self.run = self.wandb.init(project=project_name, dir=log_dir)
         print(f"Wandb is enabled. Project: {project_name}")


### PR DESCRIPTION
This PR allows the W&B logger to respect the WANDB_PROJECT
  environment variable.

  Previously, WandbLogger always used the explicit
  project_name argument passed to wandb.init(), which
  defaulted to DiffSynth-Studio. This meant that setting
  WANDB_PROJECT in the environment did not change the W&B
  project name.

  With this change, WandbLogger reads WANDB_PROJECT before
  calling wandb.init(), while preserving the existing default
  behavior when the environment variable is not set.

  Changes:

  - Read WANDB_PROJECT in diffsynth/diffusion/logger.py
  - Keep the default project name as DiffSynth-Studio
  - No changes to run name behavior or other logger behavior

  Validation:

  - Ran python3 -m py_compile diffsynth/diffusion/logger.py

  这个 PR 让 W&B logger 支持读取 WANDB_PROJECT 环境变量。

  之前 WandbLogger 会把显式传入的 project_name 传给
  wandb.init()，默认值是 DiffSynth-Studio。因此即使用户在环境
  变量里设置了 WANDB_PROJECT，W&B project 名称也不会被覆盖。

  这个改动会在调用 wandb.init() 前读取 WANDB_PROJECT。如果没
  有设置该环境变量，则保持原来的默认行为不变。

  变更内容：

  - 在 diffsynth/diffusion/logger.py 中读取 WANDB_PROJECT
  - 默认 project 仍然保持为 DiffSynth-Studio
  - 不改变 run name 或其他 logger 行为

  验证：

  - 已运行 python3 -m py_compile diffsynth/diffusion/
    logger.py