### PR TITLE
feat: save training args to output_path/training_args.json

### DIFF
--- a/diffsynth/diffusion/runner.py
+++ b/diffsynth/diffusion/runner.py
@@ -1,4 +1,4 @@
-import os, torch, importlib
+import os, json, torch, importlib
 from tqdm import tqdm
 from accelerate import Accelerator
 from .training_module import DiffusionTrainingModule
@@ -14,6 +14,25 @@ def get_optimizer_class(customized_optimizer=None):
         module = importlib.import_module(module_name)
         print(f"Customized opimizer `{customized_optimizer}` imported.")
         return getattr(module, class_name)
+
+
+def save_training_args(accelerator: Accelerator, model_logger: ModelLogger, args):
+    """Dump the parsed training arguments to ``output_path/training_args.json`` for reproducibility.
+
+    Saving is best-effort: a failure here (a non-serializable value, a permission error, a full disk, ...)
+    should never interrupt training, so any exception is caught and reported as a warning. ``default=str``
+    keeps the dump robust if a future argument holds a non-JSON-serializable value.
+    """
+    if args is None or not accelerator.is_main_process:
+        return
+    try:
+        os.makedirs(model_logger.output_path, exist_ok=True)
+        save_path = os.path.join(model_logger.output_path, "training_args.json")
+        with open(save_path, "w", encoding="utf-8") as f:
+            json.dump(vars(args), f, indent=4, ensure_ascii=False, default=str)
+        print(f"Training arguments saved to `{save_path}`.")
+    except Exception as e:
+        print(f"Warning: failed to save training arguments: {e}")
 
 
 def launch_training_task(
@@ -43,6 +62,8 @@ def launch_training_task(
         enable_optimizer_cpu_offload = args.enable_optimizer_cpu_offload
         cpu_offload_split_threshold = args.cpu_offload_split_threshold
         customized_optimizer = args.customized_optimizer
+
+    save_training_args(accelerator, model_logger, args)
 
     optimizer_class = get_optimizer_class(customized_optimizer)
     optimizer = optimizer_class(model.trainable_modules(), lr=learning_rate, weight_decay=weight_decay)


### PR DESCRIPTION
## What

Persist the parsed training arguments as `training_args.json` under `--output_path` at the start of every training run.

## Why

Closes #1484. Currently `output_path` only contains checkpoints, so reproducing a run means recovering the exact launch command by hand. Saving the args alongside the checkpoints makes every run self-describing and reproducible.

## How

- Added a small `save_training_args()` helper in `diffsynth/diffusion/runner.py`.
- Called once at the start of `launch_training_task`. All 14 model training entrypoints (`examples/*/model_training/train.py`) route through this function, so a single change covers every model — no per-model edits.
- Only the **main process** writes the file (avoids multi-process write races under `accelerate`).
- `args=None` is handled gracefully (no-op).
- All training args are plain `str/int/float/bool/None`, so `vars(args)` is directly JSON-serializable.

Example output (`<output_path>/training_args.json`):
```json
{
    "learning_rate": 5e-05,
    "num_epochs": 5,
    "save_steps": null,
    "lora_target_modules": "q,k,v,o,ffn.0,ffn.2",
    "task": "sft:train"
}
```

## Testing

Verified locally (CPU, no GPU/model needed): main-process writes the file with correct content, non-main process skips, `args=None` is a safe no-op, and a non-existent `output_path` is created automatically.
