### PR TITLE
feat: support http(s) image URLs in training metadata

### DIFF
--- a/diffsynth/core/data/operators.py
+++ b/diffsynth/core/data/operators.py
@@ -1,7 +1,25 @@
 import math, warnings
 import torch, torchvision, imageio, os
 import imageio.v3 as iio
+import urllib.request
+from io import BytesIO
 from PIL import Image
+
+
+def _is_url(path):
+    return isinstance(path, str) and path.startswith(("http://", "https://"))
+
+
+def _load_image_from_url(url, timeout=30):
+    # A custom User-Agent avoids the 403 that many CDNs / image hosts return for the default urllib agent.
+    request = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; DiffSynth-Studio)"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            image = Image.open(BytesIO(response.read()))
+            image.load()  # force a full decode while the byte buffer is still in scope
+        return image
+    except Exception as e:
+        raise RuntimeError(f"Failed to load image from URL '{url}': {e}") from e
 
 
 class DataProcessingPipeline:
@@ -54,12 +72,16 @@ class ToStr(DataProcessingOperator):
 
 
 class LoadImage(DataProcessingOperator):
-    def __init__(self, convert_RGB=True, convert_RGBA=False):
+    def __init__(self, convert_RGB=True, convert_RGBA=False, timeout=30):
         self.convert_RGB = convert_RGB
         self.convert_RGBA = convert_RGBA
-    
+        self.timeout = timeout
+
     def __call__(self, data: str):
-        image = Image.open(data)
+        if _is_url(data):
+            image = _load_image_from_url(data, timeout=self.timeout)
+        else:
+            image = Image.open(data)
         if self.convert_RGB: image = image.convert("RGB")
         if self.convert_RGBA: image = image.convert("RGBA")
         return image
@@ -241,6 +263,9 @@ class ToAbsolutePath(DataProcessingOperator):
         self.base_path = base_path
         
     def __call__(self, data):
+        # A remote URL is already absolute; joining it with base_path would corrupt it.
+        if _is_url(data):
+            return data
         return os.path.join(self.base_path, data)
 
 


### PR DESCRIPTION
Hi! Small enhancement to let training datasets reference images by URL.

### Problem

The training `metadata.csv`/`jsonl` only works with local image paths. A row whose image column is a remote URL fails, because the image is loaded through `ToAbsolutePath(base_path) >> LoadImage()`:

- `ToAbsolutePath.__call__` does `os.path.join(base_path, data)`, turning `https://example.com/img.png` into `data/https://example.com/img.png`.
- `LoadImage.__call__` then calls `Image.open(...)` on that corrupted path and raises `FileNotFoundError`.

So datasets hosted on object storage / a CDN currently have to be fully downloaded to local disk first, even though every other part of the pipeline is happy to stream.

### Fix

Two small changes in `diffsynth/core/data/operators.py`, plus a shared `_is_url` helper:

- `ToAbsolutePath`: a URL is already absolute, so pass it through unchanged instead of joining it onto `base_path`.
- `LoadImage`: if the input is a URL, download it (`urllib.request`, stdlib — no new dependency) and open from an in-memory buffer; otherwise `Image.open(path)` exactly as before. A `timeout` (default 30s) is added so a hung host can't block training forever.

Deliberately **not** touched:
- **Local paths** — identical behavior (the URL branch only triggers on `http://`/`https://`).
- **Video / GIF loaders** (`LoadVideo`, `LoadGIF`) — out of scope for this PR; this is the image path the issue asks about. They keep working exactly as today for local files.
- No caching layer — kept minimal; each access re-fetches. Can be added later if wanted.

### Testing

Served a real 64×48 PNG from a local `http.server` and ran both operators on each input style:

| operator | input | before | after |
|---|---|---|---|
| `ToAbsolutePath` | local `"pic.png"` | `base/pic.png` | `base/pic.png` (unchanged) |
| `ToAbsolutePath` | `http://.../pic.png` | `base/http://.../pic.png` (corrupted) | `http://.../pic.png` (passed through) |
| `LoadImage` | local path | PIL RGB 64×48 | PIL RGB 64×48 (unchanged) |
| `LoadImage` | `http://.../pic.png` | `FileNotFoundError` | PIL RGB 64×48 |

Local paths are byte-for-byte unchanged; URLs now load correctly end-to-end (`ToAbsolutePath` passthrough → `LoadImage` download).
