### PR TITLE
fix: clamp DDIM scheduler timestep index to avoid bf16 overflow

### DIFF
--- a/diffsynth/diffusion/ddim_scheduler.py
+++ b/diffsynth/diffusion/ddim_scheduler.py
@@ -66,8 +66,15 @@ class DDIMScheduler():
         return prev_sample
 
 
+    def _timestep_index(self, timestep):
+        # bfloat16 cannot represent 999 exactly and rounds it up to 1000, which
+        # would overflow alphas_cumprod (length num_train_timesteps); clamp it.
+        index = int(timestep.flatten().tolist()[0])
+        return min(max(index, 0), self.num_train_timesteps - 1)
+
+
     def step(self, model_output, timestep, sample, to_final=False):
-        alpha_prod_t = self.alphas_cumprod[int(timestep.flatten().tolist()[0])]
+        alpha_prod_t = self.alphas_cumprod[self._timestep_index(timestep)]
         if isinstance(timestep, torch.Tensor):
             timestep = timestep.cpu()
         timestep_id = torch.argmin((self.timesteps - timestep).abs())
@@ -81,14 +88,14 @@ class DDIMScheduler():
 
 
     def return_to_timestep(self, timestep, sample, sample_stablized):
-        alpha_prod_t = self.alphas_cumprod[int(timestep.flatten().tolist()[0])]
+        alpha_prod_t = self.alphas_cumprod[self._timestep_index(timestep)]
         noise_pred = (sample - math.sqrt(alpha_prod_t) * sample_stablized) / math.sqrt(1 - alpha_prod_t)
         return noise_pred
     
     
     def add_noise(self, original_samples, noise, timestep):
-        sqrt_alpha_prod = math.sqrt(self.alphas_cumprod[int(timestep.flatten().tolist()[0])])
-        sqrt_one_minus_alpha_prod = math.sqrt(1 - self.alphas_cumprod[int(timestep.flatten().tolist()[0])])
+        sqrt_alpha_prod = math.sqrt(self.alphas_cumprod[self._timestep_index(timestep)])
+        sqrt_one_minus_alpha_prod = math.sqrt(1 - self.alphas_cumprod[self._timestep_index(timestep)])
         noisy_samples = sqrt_alpha_prod * original_samples + sqrt_one_minus_alpha_prod * noise
         return noisy_samples
     
@@ -97,8 +104,8 @@ class DDIMScheduler():
         if self.prediction_type == "epsilon":
             return noise
         else:
-            sqrt_alpha_prod = math.sqrt(self.alphas_cumprod[int(timestep.flatten().tolist()[0])])
-            sqrt_one_minus_alpha_prod = math.sqrt(1 - self.alphas_cumprod[int(timestep.flatten().tolist()[0])])
+            sqrt_alpha_prod = math.sqrt(self.alphas_cumprod[self._timestep_index(timestep)])
+            sqrt_one_minus_alpha_prod = math.sqrt(1 - self.alphas_cumprod[self._timestep_index(timestep)])
             target = sqrt_alpha_prod * noise - sqrt_one_minus_alpha_prod * sample
             return target
         

--- a/tests/test_ddim_scheduler.py
+++ b/tests/test_ddim_scheduler.py
@@ -1,0 +1,27 @@
+import torch
+
+from diffsynth.diffusion.ddim_scheduler import DDIMScheduler
+
+
+def test_bf16_timestep_does_not_overflow_alphas_cumprod():
+    # Regression for #1499: in bfloat16 training a timestep of 999 rounds up
+    # (999 is not exactly representable in bf16), which used to index past
+    # alphas_cumprod (length num_train_timesteps) and raise IndexError.
+    scheduler = DDIMScheduler()
+    timestep = torch.tensor([999.0], dtype=torch.bfloat16)
+
+    # The bf16 round-trip pushes the raw timestep past the valid index range ...
+    assert int(timestep.flatten().tolist()[0]) >= scheduler.num_train_timesteps
+
+    sample = torch.zeros(1, 4, 8, 8)
+    noise = torch.randn(1, 4, 8, 8)
+    # ... yet add_noise must neither raise IndexError nor produce NaNs.
+    assert torch.isfinite(scheduler.add_noise(sample, noise, timestep)).all()
+
+    v_scheduler = DDIMScheduler(prediction_type="v_prediction")
+    assert torch.isfinite(v_scheduler.training_target(sample, noise, timestep)).all()
+
+
+if __name__ == "__main__":
+    test_bf16_timestep_does_not_overflow_alphas_cumprod()
+    print("ok")


### PR DESCRIPTION
Closes #1499.

In bf16 LoRA training `add_noise` crashes with `IndexError: list index out of range`. A timestep of 999 isn't representable in bfloat16 and rounds up to 1000, so `int(timestep.flatten().tolist()[0])` becomes 1000 and indexes past `alphas_cumprod` (length `num_train_timesteps`, valid 0–999):

```python
>>> torch.tensor(999.0).to(torch.bfloat16)
tensor(1000., dtype=torch.bfloat16)
```

Clamp the timestep to `[0, num_train_timesteps - 1]` at the `alphas_cumprod` lookups. The same `int(timestep...)` index was duplicated across `step` / `return_to_timestep` / `add_noise` / `training_target`, so I pulled it into a small `_timestep_index` helper. Inference timesteps are already in range, so the clamp is a no-op there.

Reproducible on CPU (bf16 only). Added `tests/test_ddim_scheduler.py`, which fails before (IndexError in `add_noise`) and passes after. Thanks @x1a0qiya for the diagnosis.