### PR TITLE
add krea2 liscense

### DIFF
--- a/docs/en/Model_Details/Krea-2.md
+++ b/docs/en/Model_Details/Krea-2.md
@@ -128,3 +128,8 @@ modelscope download --dataset DiffSynth-Studio/diffsynth_example_dataset --inclu
 ```
 
 We provide recommended training scripts for each model, please refer to the table in "Model Overview" above. For guidance on writing model training scripts, see [Model Training](../Pipeline_Usage/Model_Training.md); for more advanced training algorithms, see [Training Framework Overview](https://github.com/modelscope/DiffSynth-Studio/tree/main/docs/en/Training/).
+
+
+## License
+
+> **⚠️ Notice**: **Krea-2** weights (Raw and Turbo) are released under the [Krea 2 Community License](https://www.krea.ai/krea-2-licensing), **not** the Apache 2.0 license that governs DiffSynth-Studio itself.

--- a/docs/zh/Model_Details/Krea-2.md
+++ b/docs/zh/Model_Details/Krea-2.md
@@ -128,3 +128,9 @@ modelscope download --dataset DiffSynth-Studio/diffsynth_example_dataset --inclu
 ```
 
 我们为每个模型编写了推荐的训练脚本，请参考前文"模型总览"中的表格。关于如何编写模型训练脚本，请参考[模型训练](../Pipeline_Usage/Model_Training.md)；更多高阶训练算法，请参考[训练框架详解](https://github.com/modelscope/DiffSynth-Studio/tree/main/docs/zh/Training/)。
+
+
+
+## 许可协议
+
+> **⚠️ 提示**：**Krea-2** 权重（Raw 与 Turbo）遵循 [Krea 2 Community License](https://www.krea.ai/krea-2-licensing)，**不同于** DiffSynth-Studio 本身的 Apache 2.0 协议。


### PR DESCRIPTION
## Summary

Krea-2 weights (Raw and Turbo) are released by Krea AI under the [Krea 2 Community License](https://www.krea.ai/krea-2-licensing), which differs from DiffSynth-Studio's own Apache-2.0 license. The current Krea-2 docs don't surface this difference, which can mislead users into assuming the same permissive terms apply.

## Changes

- `docs/en/Model_Details/Krea-2.md`: add a `## License` section with a one-line callout pointing to the official Krea 2 Community License.
- `docs/zh/Model_Details/Krea-2.md`: add a corresponding `## 许可协议` section.