### PR TITLE
Fix Head modulation broadcast for batch size > 1 in WanModel

### DIFF
--- a/diffsynth/models/wan_video_dit.py
+++ b/diffsynth/models/wan_video_dit.py
@@ -279,7 +279,7 @@ class Head(nn.Module):
             shift, scale = (self.modulation.unsqueeze(0).to(dtype=t_mod.dtype, device=t_mod.device) + t_mod.unsqueeze(2)).chunk(2, dim=2)
             x = (self.head(self.norm(x) * (1 + scale.squeeze(2)) + shift.squeeze(2)))
         else:
-            shift, scale = (self.modulation.to(dtype=t_mod.dtype, device=t_mod.device) + t_mod).chunk(2, dim=1)
+            shift, scale = (self.modulation.to(dtype=t_mod.dtype, device=t_mod.device) + t_mod.unsqueeze(1)).chunk(2, dim=1)
             x = (self.head(self.norm(x) * (1 + scale) + shift))
         return x
 


### PR DESCRIPTION
Fixes #1516.

`Head.forward` only works for batch size 1 when `t_mod` is 2D `(b, dim)`. `self.modulation` is `(1, 2, dim)`, so `modulation + t_mod` broadcasts `(1, 2, dim)` against `(b, dim)`: the `2` and `b` dims line up, so it silently mismatches at b=2 and raises at b>=3. The normal forward path hits this — `self.head(x, t)` passes the per-sample time embedding `t` of shape `(b, dim)`.

Unsqueeze `t_mod` to `(b, 1, dim)` so it broadcasts against `(1, 2, dim)` -> `(b, 2, dim)`, matching the 3D branch just above. b=1 output is unchanged and the 3D per-token branch is untouched.

Repro on current main (raises at b>=3):

```python
import torch
from diffsynth.models.wan_video_dit import Head
head = Head(dim=16, out_dim=4, patch_size=(1,2,2), eps=1e-6)
head(torch.randn(3, 5, 16), torch.randn(3, 16))
# RuntimeError: The size of tensor a (2) must match the size of tensor b (3) at non-singleton dimension 1
```
