### PR TITLE
Re-export get_sequence_parallel_rank and get_sp_group from xfuser utils

### DIFF
--- a/diffsynth/utils/xfuser/__init__.py
+++ b/diffsynth/utils/xfuser/__init__.py
@@ -1,1 +1,1 @@
-from .xdit_context_parallel import usp_attn_forward, usp_dit_forward, usp_vace_forward, get_sequence_parallel_world_size, initialize_usp, get_current_chunk, gather_all_chunks
+from .xdit_context_parallel import usp_attn_forward, usp_dit_forward, usp_vace_forward, get_sequence_parallel_world_size, get_sequence_parallel_rank, get_sp_group, initialize_usp, get_current_chunk, gather_all_chunks


### PR DESCRIPTION
Fixes #1520.

`diffsynth/utils/xfuser/__init__.py` re-exports `get_sequence_parallel_world_size` but not the two companion APIs `get_sequence_parallel_rank` and `get_sp_group`, even though all three are imported together from `xfuser.core.distributed` in `xdit_context_parallel.py` and used throughout it. This adds the two missing names to the re-export so they can be imported from `diffsynth.utils.xfuser` the same way as their sibling.
