### PR TITLE
Fix float8_e4m3fnuz input scaling range

### DIFF
--- a/diffsynth/core/vram/layers.py
+++ b/diffsynth/core/vram/layers.py
@@ -330,13 +330,8 @@ class AutoWrappedLinear(torch.nn.Linear, AutoTorchModule):
         input = input.reshape(-1, origin_shape[-1])
 
         x_max = torch.max(torch.abs(input), dim=-1, keepdim=True).values
-        fp8_max = 448.0
-        # For float8_e4m3fnuz, the maximum representable value is half of that of e4m3fn.
-        # To avoid overflow and ensure numerical compatibility during FP8 computation,
-        # we scale down the input by 2.0 in advance.
-        # This scaling will be compensated later during the final result scaling.
-        if self.computation_dtype == torch.float8_e4m3fnuz:
-            fp8_max = fp8_max / 2.0
+        # Use the maximum finite value defined by the selected FP8 dtype.
+        fp8_max = torch.finfo(self.computation_dtype).max
         scale_a = torch.clamp(x_max / fp8_max, min=1.0).float().to(device=device)
         scale_b = torch.ones((weight.shape[0], 1)).to(device=device)
         input = input / (scale_a + 1e-8)


### PR DESCRIPTION
## Summary

In `diffsynth/core/vram/layers.py`, `AutoWrappedLinear.fp8_linear()` currently initializes the FP8 input scaling threshold to 448 and divides it by 2 for `torch.float8_e4m3fnuz`:

```python
fp8_max = 448.0
if self.computation_dtype == torch.float8_e4m3fnuz:
    fp8_max = fp8_max / 2.0
```

This produces a threshold of 224, while the maximum finite value defined for `torch.float8_e4m3fnuz` is 240.

This PR replaces the manually derived threshold with the maximum finite value defined by the selected dtype:

```python
fp8_max = torch.finfo(self.computation_dtype).max
```

As a result:

- `torch.float8_e4m3fn` continues to use 448.
- `torch.float8_e4m3fnuz` now uses 240 instead of 224.

## Scaling behavior

Let \(M\) be the maximum absolute value of an input row. For `torch.float8_e4m3fnuz`, the old and new scales are:

$$
s_{\mathrm{old}}(M) = \max\left(\frac{M}{224}, 1\right)
$$

$$
s_{\mathrm{new}}(M) = \max\left(\frac{M}{240}, 1\right)
$$

Therefore:

- For $M \leq 224$, the behavior is unchanged.
- For $224 < M \leq 240$, the new implementation avoids unnecessary scaling.
- For $M > 240$, the row is still scaled, but the full finite range of `torch.float8_e4m3fnuz` is used.