### PR TITLE
fix: clone CPU tensors before refreshing disk map files

### DIFF
--- a/diffsynth/core/vram/disk_map.py
+++ b/diffsynth/core/vram/disk_map.py
@@ -62,7 +62,7 @@ class DiskMap:
         param = self.files[file_id].get_tensor(name)
         if self.torch_dtype is not None and isinstance(param, torch.Tensor):
             param = param.to(self.torch_dtype)
-        if isinstance(param, torch.Tensor) and param.device == "cpu":
+        if isinstance(param, torch.Tensor) and param.device.type == "cpu":
             param = param.clone()
         if isinstance(param, torch.Tensor):
             self.num_params += param.numel()


### PR DESCRIPTION
## Summary

- use param.device.type when detecting CPU tensors in DiskMap
- ensure safetensors-backed CPU tensors are cloned before file handles can be refreshed

## Root cause

On recent PyTorch versions, comparing torch.device("cpu") directly with the string "cpu" returns false. The existing guard therefore skipped the defensive clone and could leave returned tensors referencing an mmap that flush_files() later replaces, leading to invalid storage access and excess mapped memory.

## Validation

- python -m py_compile diffsynth/core/vram/disk_map.py
- verified a CPU tensor returned by DiskMap has different storage from the loader tensor
- forced a safetensors handle refresh with buffer_size=0 and verified the returned tensor remains readable
- git diff --check

Closes #1600.