### PR TITLE
fix ram leak

### DIFF
--- a/diffsynth/core/device/npu_compatible_device.py
+++ b/diffsynth/core/device/npu_compatible_device.py
@@ -83,17 +83,17 @@ def enable_high_precision_for_bf16():
 
 
 def parse_device_type(device):
-    if isinstance(device, str):
-        if device.startswith("cuda"):
-            return "cuda"
-        elif device.startswith("npu"):
-            return "npu"
-        elif device.startswith("mps"):
-            return "mps"
-        else:
-            return "cpu"
-    elif isinstance(device, torch.device):
+    if isinstance(device, torch.device):
         return device.type
+    elif isinstance(device, str):
+        # `torch.device("npu")` raises when torch_npu is not installed, so keep npu ahead of the generic parse.
+        if device.startswith("npu"):
+            return "npu"
+        try:
+            return torch.device(device).type
+        except RuntimeError:
+            # Strings that are not device names at all
+            return "cpu"
 
 
 def parse_nccl_backend(device_type):

--- a/diffsynth/core/vram/disk_map.py
+++ b/diffsynth/core/vram/disk_map.py
@@ -62,7 +62,7 @@ class DiskMap:
         param = self.files[file_id].get_tensor(name)
         if self.torch_dtype is not None and isinstance(param, torch.Tensor):
             param = param.to(self.torch_dtype)
-        if isinstance(param, torch.Tensor) and param.device == "cpu":
+        if isinstance(param, torch.Tensor) and param.device.type == "cpu":
             param = param.clone()
         if isinstance(param, torch.Tensor):
             self.num_params += param.numel()

--- a/diffsynth/utils/xfuser/xdit_context_parallel.py
+++ b/diffsynth/utils/xfuser/xdit_context_parallel.py
@@ -36,7 +36,7 @@ def pad_freqs(original_tensor, target_len):
     seq_len, s1, s2 = original_tensor.shape
     pad_size = target_len - seq_len
     original_tensor_device = original_tensor.device
-    if original_tensor.device == "npu":
+    if original_tensor.device.type == "npu":
         original_tensor = original_tensor.cpu()
     padding_tensor = torch.ones(
         pad_size,


### PR DESCRIPTION
# Fix: device-vs-string comparisons silently break on torch ≥ 2.9

Related: #1606

## Root cause

`torch.device.__eq__` only accepts `torch.device`. Given a string it returns `NotImplemented`, the reflected `str.__eq__` does too, so Python falls back to identity comparison — always `False`. torch ≤ 2.8 coerced the string first; 2.9 dropped that, with no warning (pytorch/pytorch#153418).

Measured on torch 2.10.0+cu128: `torch.device('cpu') == 'cpu'` → **False**, `tensor.device == 'cpu'` → **False**, `tensor.device.type == 'cpu'` → True.

Three comparisons in the repo are affected. Device-type checks are unified on `.device.type` (tensor side) / `parse_device_type` (config side). Comparing `torch.device` objects is not an option: `tensor.device` always carries an index (`cuda:0`), which never equals `torch.device("cuda")`, and `torch.device("disk")` raises — `"disk"` being a VRAM-management sentinel.

---

## 1. `core/vram/disk_map.py` — the clone guard never ran

```diff
- if isinstance(param, torch.Tensor) and param.device == "cpu":
+ if isinstance(param, torch.Tensor) and param.device.type == "cpu":
      param = param.clone()
```

On CPU, `safe_open().get_tensor()` returns a zero-copy mmap view. `flush_files()` reopens the handle to release its buffer, and any leaked view pins the old mapping forever. This `clone()` is the only defense, and it never fired. There is no fallback either: `load_from_disk()` calls `.to(dtype=bf16, device="cpu")`, a no-op for a bf16 checkpoint with `onload_dtype=bf16` — the reporter's exact config.

### How it was measured

Both experiments drive the real path — `load_model(module_map=..., vram_config=<reporter's config verbatim>)` → `DiskMap(path, "cpu")` → `enable_vram_management` → `AutoWrappedLinear.onload()` — on a bf16 checkpoint. "Before" restores the old semantics by monkeypatching `DiskMap.__getitem__` back to `param.device == "cpu"`; "after" is this PR's code. Nothing else differs.

**A. Is each weight an independent copy?** `DiskMap.__getitem__` is wrapped so that, *at retrieval time*, the returned tensor's `data_ptr()` is compared against `files[i].get_tensor(name).data_ptr()` from the same handle. Equal pointers ⇒ still an mmap view. (Comparing after the fact is invalid: a flush reopens the handle at a new address, which hides earlier leaks.) 33 Linear layers, 34 CPU reads:

| | Before | After |
| --- | --- | --- |
| Reads returning an mmap view | **34 / 34** | **0 / 34** |
| Max weight error vs. source after flush | 0.0 | 0.0 |
| Real CUDA forward | finite | finite |

**B. Does it show up in memory?** 1.03 GB bf16 checkpoint; `buffer_size` set to one layer's element count so nearly every layer triggers a flush; 5 offload/onload cycles. Per snapshot: `VmSize` from `/proc/self/status`, and live mappings of the weight file counted in `/proc/self/maps`.

| | Before | After |
| --- | --- | --- |
| Live mappings of the same file | **18** | **1** |
| Total mapped | **18.56 GB** (18.0× the file) | 1.03 GB (1.0×) |
| Peak VmSize | 32.35 GB | 16.81 GB |

Before the fix, one onload sweep adds 16 mappings (`+16.5 GB` VmSize) and offload releases them; after the fix the count stays at 1 throughout.

Mappings ≈ `total_params / buffer_size`, so the amplification scales with model size. The reporter's default `buffer_size=1e9` with 43.5 GB of weights predicts ≈3.3×, matching their "43.5 GB weights → 289 GB committed" and the exhausted 256 GB pagefile.

Cost: onload holds one extra copy of the weights in anonymous memory (that is what the `clone()` was for), instead of 18× mapping amplification plus dangling pointers.

---

## 2. `core/device/npu_compatible_device.py` — `parse_device_type` reported xpu as cpu

```diff
- if isinstance(device, str):
-     if device.startswith("cuda"): return "cuda"
-     elif device.startswith("npu"): return "npu"
-     elif device.startswith("mps"): return "mps"
-     else: return "cpu"
- elif isinstance(device, torch.device):
-     return device.type
+ if isinstance(device, torch.device):
+     return device.type
+ elif isinstance(device, str):
+     if device.startswith("npu"):          # torch.device("npu") raises without torch_npu
+         return "npu"
+     try:
+         return torch.device(device).type
+     except RuntimeError:                  # "disk" sentinel, unsupported backends, typos
+         return "cpu"
```

The reporter runs `device="xpu"`, which the `else` branch turned into `"cpu"` → `getattr(torch, "cpu").empty_cache()` → `AttributeError: module 'torch.cpu' has no attribute 'empty_cache'`. Adding another `elif` would only postpone the problem: a missing backend degrades *silently* to cpu, which is how xpu slipped through. `torch.device()` makes torch the authority on device names and strips the index for free; the npu check stays in front because `torch.device("npu")` raises without `torch_npu`.

### Coverage, old vs. new

34 exhaustive inputs (every device name × with/without index × `str`/`torch.device`, plus the `"disk"` sentinel, invalid strings, `None`, non-device types) mapped onto the 6 reachable branches of the old function:

All change is confined to the `else` branch — the one that could not tell "genuinely cpu" from "name I don't recognize". Its 14 inputs split into:

- unchanged `"cpu"`: `"cpu"`, `"cpu:0"`, `"disk"`, `"mlu"`, `"mlu:0"`, `""`, `"nonexistent_device"`
- corrected: `"xpu"`/`"xpu:0"`/`"xpu:1"` → `xpu`, `"hpu"`/`"hpu:0"` → `hpu`, `"mtia"` → `mtia`, `"meta"` → `meta`

`torch.hpu` and `torch.meta` do not exist as namespaces, but nothing in the repo passes `meta`/`hpu` as a runtime compute device, so dispatch is unaffected.

---

## 3. `utils/xfuser/xdit_context_parallel.py` — dead NPU branch

```diff
- if original_tensor.device == "npu":
+ if original_tensor.device.type == "npu":
```

This never ran, not even before 2.9: tensors report `npu:0` while `torch.device("npu")` has `index=None`. The workaround now actually executes; numerically equivalent, one extra small H2D/D2H.

---

## Compatibility

`torch.device.type` has been public since torch 0.4 and does not participate in `__eq__`, so no version branching is needed (project requires `torch>=2.0.0`).

Environment: python 3.10.20 / torch 2.10.0+cu128 / safetensors 0.8.0 / A100-80GB.
