### PR TITLE
docs: 修复 README 中的失效链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ We believe that a well-developed open-source code framework can lower the thresh
     - Z-Image Turbo: [Model](https://www.modelscope.ai/models/Tongyi-MAI/Z-Image-Turbo), [Documentation](/docs/en/Model_Details/Z-Image.md), [Code](/examples/z_image/)
     - FLUX.2-dev: [Model](https://www.modelscope.cn/models/black-forest-labs/FLUX.2-dev), [Documentation](/docs/en/Model_Details/FLUX2.md), [Code](/examples/flux2/)
   - Training framework upgrade
-    - [Split Training](/docs/zh/Training/Split_Training.md): Supports automatically splitting the training process into two stages: data processing and training (even for training ControlNet or any other model). Computations that do not require gradient backpropagation, such as text encoding and VAE encoding, are performed during the data processing stage, while other computations are handled during the training stage. Faster speed, less VRAM requirement.
-    - [Differential LoRA Training](/docs/zh/Training/Differential_LoRA.md): This is a training technique we used in [ArtAug](https://www.modelscope.cn/models/DiffSynth-Studio/ArtAug-lora-FLUX.1dev-v1), now available for LoRA training of any model.
-    - [FP8 Training](/docs/zh/Training/FP8_Precision.md): FP8 can be applied to any non-training model during training, i.e., models with gradients turned off or gradients that only affect LoRA weights.
+    - [Split Training](/docs/en/Training/Split_Training.md): Supports automatically splitting the training process into two stages: data processing and training (even for training ControlNet or any other model). Computations that do not require gradient backpropagation, such as text encoding and VAE encoding, are performed during the data processing stage, while other computations are handled during the training stage. Faster speed, less VRAM requirement.
+    - [Differential LoRA Training](/docs/en/Training/Differential_LoRA.md): This is a training technique we used in [ArtAug](https://www.modelscope.cn/models/DiffSynth-Studio/ArtAug-lora-FLUX.1dev-v1), now available for LoRA training of any model.
+    - [FP8 Training](/docs/en/Training/FP8_Precision.md): FP8 can be applied to any non-training model during training, i.e., models with gradients turned off or gradients that only affect LoRA weights.
 
 - **November 4, 2025** Supported the [ByteDance/Video-As-Prompt-Wan2.1-14B](https://modelscope.cn/models/ByteDance/Video-As-Prompt-Wan2.1-14B) model, which is trained based on Wan 2.1 and supports generating corresponding actions based on reference videos.
 
@@ -1795,13 +1795,13 @@ Example code for image quality metrics models can be found at: [/examples/image_
 
 | Metric | GitHub Repository | Example Code |
 | - | - | - |
-| PickScore | [GitHub](https://github.com/yuvalkirstain/pickscore) | [code](../../../examples/image_quality_metric/pickscore.py) |
-| ImageReward | [GitHub](https://github.com/zai-org/ImageReward) | [code](../../../examples/image_quality_metric/image_reward.py) |
-| HPSv2 | [GitHub](https://github.com/tgxs002/HPSv2) | [code](../../../examples/image_quality_metric/hpsv2.py) |
-| HPSv3 | [GitHub](https://github.com/MizzenAI/HPSv3) | [code](../../../examples/image_quality_metric/hpsv3.py) |
-| CLIP Score | [GitHub](https://github.com/openai/CLIP) | [code](../../../examples/image_quality_metric/clipscore.py) |
-| Aesthetic | [GitHub](https://github.com/christophschuhmann/improved-aesthetic-predictor) | [code](../../../examples/image_quality_metric/aesthetic.py) |
-| FID | [GitHub](https://github.com/mseitzer/pytorch-fid) | [code](../../../examples/image_quality_metric/fid.py) |
+| PickScore | [GitHub](https://github.com/yuvalkirstain/pickscore) | [code](./examples/image_quality_metric/pickscore.py) |
+| ImageReward | [GitHub](https://github.com/zai-org/ImageReward) | [code](./examples/image_quality_metric/image_reward.py) |
+| HPSv2 | [GitHub](https://github.com/tgxs002/HPSv2) | [code](./examples/image_quality_metric/hpsv2.py) |
+| HPSv3 | [GitHub](https://github.com/MizzenAI/HPSv3) | [code](./examples/image_quality_metric/hpsv3.py) |
+| CLIP Score | [GitHub](https://github.com/openai/CLIP) | [code](./examples/image_quality_metric/clipscore.py) |
+| Aesthetic | [GitHub](https://github.com/christophschuhmann/improved-aesthetic-predictor) | [code](./examples/image_quality_metric/aesthetic.py) |
+| FID | [GitHub](https://github.com/mseitzer/pytorch-fid) | [code](./examples/image_quality_metric/fid.py) |
 
 </details>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1795,13 +1795,13 @@ print(f"PickScore score:: {score:.3f}")
 
 |指标|GitHub 仓库|示例代码|
 |-|-|-|
-|PickScore|[GitHub](https://github.com/yuvalkirstain/pickscore)|[code](../../../examples/image_quality_metric/pickscore.py)|
-|ImageReward|[GitHub](https://github.com/zai-org/ImageReward)|[code](../../../examples/image_quality_metric/image_reward.py)|
-|HPSv2|[GitHub](https://github.com/tgxs002/HPSv2)|[code](../../../examples/image_quality_metric/hpsv2.py)|
-|HPSv3|[GitHub](https://github.com/MizzenAI/HPSv3)|[code](../../../examples/image_quality_metric/hpsv3.py)|
-|CLIP Score|[GitHub](https://github.com/openai/CLIP)|[code](../../../examples/image_quality_metric/clipscore.py)|
-|Aesthetic|[GitHub](https://github.com/christophschuhmann/improved-aesthetic-predictor)|[code](../../../examples/image_quality_metric/aesthetic.py)|
-|FID|[GitHub](https://github.com/mseitzer/pytorch-fid)|[code](../../../examples/image_quality_metric/fid.py)|
+|PickScore|[GitHub](https://github.com/yuvalkirstain/pickscore)|[code](./examples/image_quality_metric/pickscore.py)|
+|ImageReward|[GitHub](https://github.com/zai-org/ImageReward)|[code](./examples/image_quality_metric/image_reward.py)|
+|HPSv2|[GitHub](https://github.com/tgxs002/HPSv2)|[code](./examples/image_quality_metric/hpsv2.py)|
+|HPSv3|[GitHub](https://github.com/MizzenAI/HPSv3)|[code](./examples/image_quality_metric/hpsv3.py)|
+|CLIP Score|[GitHub](https://github.com/openai/CLIP)|[code](./examples/image_quality_metric/clipscore.py)|
+|Aesthetic|[GitHub](https://github.com/christophschuhmann/improved-aesthetic-predictor)|[code](./examples/image_quality_metric/aesthetic.py)|
+|FID|[GitHub](https://github.com/mseitzer/pytorch-fid)|[code](./examples/image_quality_metric/fid.py)|
 
 </details>
 


### PR DESCRIPTION
## 修改内容

- 将英文 README 中 Split Training、Differential LoRA Training 和 FP8 Training 的链接从中文文档改为对应的英文文档。
- 修正英文和中文 README 中 14 个图像质量评测示例链接，使其指向仓库内实际存在的 examples/image_quality_metric 脚本。

## 验证

- 已检查 3 个英文训练文档链接和 14 个评测脚本链接，17 个目标文件均存在
- git diff 检查通过
- 未修改替代位置不明确的历史示例链接