### PR TITLE
fix(dmd2): restore multistep backward simulation

### DIFF
--- a/diffsynth/diffusion/dmd2.py
+++ b/diffsynth/diffusion/dmd2.py
@@ -126,6 +126,27 @@ def _scale_noise(noise, sigma):
     return (noise * sigma).to(original_dtype)
 
 
+def _ode_step(latents, x0, sigma, next_sigma):
+    """Advance a flow-matching sample from ``sigma`` to ``next_sigma``."""
+    original_dtype = latents.dtype
+    latents = latents.to(torch.float64)
+    x0 = x0.to(torch.float64)
+    sigma = _expand_like(sigma, latents)
+    next_sigma = _expand_like(next_sigma, latents)
+    if torch.any(sigma == 0):
+        raise ValueError("DMD2 ODE sampling cannot step from sigma=0.")
+    flow = (latents - x0) / sigma
+    return (latents + flow * (next_sigma - sigma)).to(original_dtype)
+
+
+def _sample_dmd2_student_step(num_steps, device):
+    """Sample one rollout step and keep it aligned across distributed ranks."""
+    step_id = torch.randint(0, num_steps, (1,), device=device)
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        torch.distributed.broadcast(step_id, src=0)
+    return int(step_id.item())
+
+
 def make_dmd2_student_schedule(
     pipe,
     num_steps,
@@ -291,8 +312,12 @@ class DMD2Loss:
 
     def _generate_student_data(self, module, real_data, inputs_shared, inputs_posi):
         pipe = module.pipe
-        device, dtype = real_data.device, real_data.dtype
+        device = real_data.device
         batch_size = real_data.shape[0]
+        if self.config.student_sample_steps < 1:
+            raise ValueError("`dmd2_student_sample_steps` must be at least 1.")
+        if self.config.student_sample_type not in {"sde", "ode"}:
+            raise ValueError(f"Unsupported DMD2 student sample type: {self.config.student_sample_type}")
         student_sigmas, student_timesteps = make_dmd2_student_schedule(
             pipe,
             self.config.student_sample_steps,
@@ -304,19 +329,43 @@ class DMD2Loss:
         if len(student_sigmas) != self.config.student_sample_steps + 1:
             raise ValueError("The student sigma schedule length must equal `student_sample_steps + 1`.")
 
-        if self.config.student_sample_steps == 1:
-            timestep = student_timesteps[0:1].expand(batch_size)
-            sigma = student_sigmas[0:1].expand(batch_size)
-            input_student = _scale_noise(torch.randn_like(real_data), sigma)
-        else:
-            step_id = torch.randint(0, self.config.student_sample_steps, (batch_size,), device=device)
-            sigma = student_sigmas[step_id]
-            timestep = student_timesteps[step_id]
-            eps_student = torch.randn_like(real_data)
-            input_student = _forward_process(real_data, eps_student, sigma)
+        selected_step = 0
+        if self.config.student_sample_steps > 1:
+            selected_step = _sample_dmd2_student_step(self.config.student_sample_steps, device)
+
+        student_model = get_dmd2_student_model(module)
+        initial_sigma = student_sigmas[0:1].expand(batch_size)
+        input_student = _scale_noise(torch.randn_like(real_data), initial_sigma)
+
+        # DMD2's backward simulation trains the selected step on inputs produced
+        # by the preceding student steps, matching the rollout seen at inference.
+        # Previous steps build the input distribution only; gradients belong to
+        # the selected step below.
+        with torch.no_grad():
+            for rollout_step in range(selected_step):
+                rollout_sigma = student_sigmas[rollout_step:rollout_step + 1].expand(batch_size)
+                rollout_timestep = student_timesteps[rollout_step:rollout_step + 1].expand(batch_size)
+                rollout_x0 = self._model_forward_x0(
+                    module,
+                    student_model,
+                    module.dmd2_model_fn_student,
+                    input_student,
+                    rollout_timestep,
+                    rollout_sigma,
+                    inputs_shared,
+                    inputs_posi,
+                )
+                next_sigma = student_sigmas[rollout_step + 1:rollout_step + 2].expand(batch_size)
+                if self.config.student_sample_type == "sde":
+                    input_student = _forward_process(rollout_x0, torch.randn_like(real_data), next_sigma)
+                else:
+                    input_student = _ode_step(input_student, rollout_x0, rollout_sigma, next_sigma)
+
+        sigma = student_sigmas[selected_step:selected_step + 1].expand(batch_size)
+        timestep = student_timesteps[selected_step:selected_step + 1].expand(batch_size)
         gen_data = self._model_forward_x0(
             module,
-            get_dmd2_student_model(module),
+            student_model,
             module.dmd2_model_fn_student,
             input_student,
             timestep,

--- a/tests/test_dmd2_backward_simulation.py
+++ b/tests/test_dmd2_backward_simulation.py
@@ -1,0 +1,81 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from diffsynth.diffusion.dmd2 import DMD2Config, DMD2Loss, _ode_step
+
+
+class _RecordingStudent(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.flow = torch.nn.Parameter(torch.tensor(0.25))
+        self.calls = []
+
+    def forward(self, latents, timestep):
+        self.calls.append((timestep.detach().clone(), torch.is_grad_enabled()))
+        return torch.ones_like(latents) * self.flow
+
+
+def _model_fn(pipe, model, timestep, progress_id, num_inference_steps, inputs_shared, inputs_posi):
+    return model(inputs_shared["latents"], timestep)
+
+
+def _make_module():
+    student = _RecordingStudent()
+    pipe = SimpleNamespace(
+        scheduler=SimpleNamespace(num_train_timesteps=1000),
+        student=student,
+    )
+    module = SimpleNamespace(
+        pipe=pipe,
+        dmd2_student_model_name="student",
+        dmd2_model_fn_student=_model_fn,
+    )
+    return module, student
+
+
+class DMD2BackwardSimulationTests(unittest.TestCase):
+    def _generate(self, real_data, sample_type="sde"):
+        module, student = _make_module()
+        loss = DMD2Loss(DMD2Config(student_sample_steps=3, student_sample_type=sample_type))
+        with patch("diffsynth.diffusion.dmd2._sample_dmd2_student_step", return_value=2):
+            gen_data, input_student = loss._generate_student_data(module, real_data, {}, {})
+        return gen_data, input_student, student
+
+    def test_multistep_rollout_does_not_use_real_sample_values(self):
+        torch.manual_seed(123)
+        generated_a, input_a, _ = self._generate(torch.zeros(2, 3))
+        torch.manual_seed(123)
+        generated_b, input_b, _ = self._generate(torch.full((2, 3), 100.0))
+
+        torch.testing.assert_close(input_a, input_b)
+        torch.testing.assert_close(generated_a, generated_b)
+
+    def test_only_selected_rollout_step_tracks_gradients(self):
+        torch.manual_seed(7)
+        generated, input_student, student = self._generate(torch.zeros(2, 3))
+
+        self.assertEqual(len(student.calls), 3)
+        self.assertEqual([grad_enabled for _, grad_enabled in student.calls], [False, False, True])
+        torch.testing.assert_close(
+            torch.stack([timestep[0] for timestep, _ in student.calls]),
+            torch.tensor([999.0, 666.0, 333.0], dtype=torch.float64),
+        )
+        self.assertFalse(input_student.requires_grad)
+        self.assertTrue(generated.requires_grad)
+
+        generated.sum().backward()
+        self.assertIsNotNone(student.flow.grad)
+        self.assertNotEqual(student.flow.grad.item(), 0.0)
+
+    def test_ode_step_matches_flow_scheduler_update(self):
+        latents = torch.tensor([[2.0]], dtype=torch.float32)
+        x0 = torch.tensor([[1.0]], dtype=torch.float32)
+        result = _ode_step(latents, x0, torch.tensor([0.8]), torch.tensor([0.4]))
+        torch.testing.assert_close(result, torch.tensor([[1.5]], dtype=torch.float32))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace the multistep DMD2 path that forward-noised dataset latents with inference-time student backward simulation
- sample one selected student step across the batch and synchronize it across distributed ranks
- run preceding student steps under `torch.no_grad()`, using stochastic re-noising for SDE sampling or the FlowMatch Euler update for ODE sampling
- add CPU regression tests for real-sample independence, gradient isolation, timestep order, and the ODE update

## Why

For `dmd2_student_sample_steps > 1`, `_generate_student_data` currently constructs the selected-step input as:

```python
_forward_process(real_data, eps_student, sigma)
```

and invokes the student only once. Consequently, step *k* is trained on a forward-noised real latent instead of the distribution produced by student steps `0..k-1` at inference. The `dmd2_student_sample_type` option is also ignored.

DMD2 introduces backward simulation specifically to remove this multistep training/inference input mismatch. Its official implementation samples one step, rolls preceding student steps forward without gradients, and trains the selected step on the resulting sample:

- paper: https://proceedings.neurips.cc/paper_files/paper/2024/hash/54dcf25318f9de5a7a01f0a4125c541e-Abstract-Conference.html
- reference implementation: https://github.com/tianweiy/DMD2/blob/8d8fa55633d47cfb81bbc7a892e7248f9518763f/main/sd_unified_model.py#L127-L162

The new SDE path re-noises each preceding x0 prediction at the next student sigma. The ODE path follows the repository's FlowMatch scheduler equation:

```text
x_next = x + ((x - x0) / sigma) * (sigma_next - sigma)
```

The one-step path remains a single student prediction from schedule-scaled noise.

## Validation

```text
python -m unittest discover -s tests -p test_dmd2_backward_simulation.py -v

Ran 3 tests in 0.009s
OK
```

The same 3 tests pass in a clean Linux Python 3.10 / CPU PyTorch container (`Ran 3 tests in 0.144s`). Syntax compilation and targeted Ruff correctness checks also pass.

A baseline differential check against `origin/main` reproduces the bug: with a fixed RNG seed and selected step, changing only `real_data` from 0 to 100 changes the generated output by `66.699997`. With this patch, the generated rollout and selected-step input are identical because real data supplies only shape/device/dtype.

## Scope / limitation

This is a code-level correction of the DMD2 sampling distribution. I do not have an A100 end-to-end rerun of the FLUX.2 Klein 4B recipe, so I am opening this as a draft and am not claiming that it resolves every source of the loss oscillation reported in #1617. A before/after training-curve and sample-quality rerun is still needed.

Addresses #1617.