### PR TITLE
fix(flux2): restore Mistral processor loading

### DIFF
--- a/diffsynth/pipelines/flux2_image.py
+++ b/diffsynth/pipelines/flux2_image.py
@@ -65,7 +65,9 @@ class Flux2ImagePipeline(BasePipeline):
         pipe.vae = model_pool.fetch_model("flux2_vae")
         if tokenizer_config is not None:
             tokenizer_config.download_if_necessary()
-            pipe.tokenizer = AutoTokenizer.from_pretrained(tokenizer_config.path)
+            # Mistral3 needs its multimodal processor for structured chat content.
+            tokenizer_class = AutoTokenizer if pipe.text_encoder_qwen3 is not None else AutoProcessor
+            pipe.tokenizer = tokenizer_class.from_pretrained(tokenizer_config.path)
         
         # VRAM Management
         pipe.vram_management_enabled = pipe.check_vram_management_state()

--- a/tests/test_flux2_tokenizer_selection.py
+++ b/tests/test_flux2_tokenizer_selection.py
@@ -1,0 +1,99 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from diffsynth.pipelines import flux2_image
+
+
+class _ModelPool:
+    def __init__(self, text_encoder=None, text_encoder_qwen3=None):
+        self.models = {
+            "flux2_text_encoder": text_encoder,
+            "z_image_text_encoder": text_encoder_qwen3,
+            "flux2_dit": None,
+            "flux2_vae": None,
+        }
+
+    def fetch_model(self, name):
+        return self.models[name]
+
+
+class _TokenizerConfig:
+    path = "tokenizer-path"
+
+    def __init__(self):
+        self.downloaded = False
+
+    def download_if_necessary(self):
+        self.downloaded = True
+
+
+class Flux2TokenizerSelectionTest(unittest.TestCase):
+    def _load_pipeline(self, model_pool, tokenizer_config):
+        with (
+            patch.object(
+                flux2_image.Flux2ImagePipeline,
+                "download_and_load_models",
+                return_value=model_pool,
+            ),
+            patch.object(
+                flux2_image.Flux2ImagePipeline,
+                "check_vram_management_state",
+                return_value=False,
+            ),
+        ):
+            return flux2_image.Flux2ImagePipeline.from_pretrained(
+                torch_dtype=torch.float32,
+                device="cpu",
+                model_configs=[],
+                tokenizer_config=tokenizer_config,
+            )
+
+    def test_mistral_encoder_loads_multimodal_processor(self):
+        processor = object()
+        config = _TokenizerConfig()
+        pool = _ModelPool(text_encoder=object())
+
+        with (
+            patch.object(
+                flux2_image.AutoProcessor,
+                "from_pretrained",
+                return_value=processor,
+            ) as load_processor,
+            patch.object(
+                flux2_image.AutoTokenizer, "from_pretrained"
+            ) as load_tokenizer,
+        ):
+            pipe = self._load_pipeline(pool, config)
+
+        self.assertTrue(config.downloaded)
+        self.assertIs(pipe.tokenizer, processor)
+        load_processor.assert_called_once_with(config.path)
+        load_tokenizer.assert_not_called()
+
+    def test_qwen3_encoder_keeps_tokenizer_path(self):
+        tokenizer = object()
+        config = _TokenizerConfig()
+        pool = _ModelPool(text_encoder_qwen3=object())
+
+        with (
+            patch.object(
+                flux2_image.AutoProcessor, "from_pretrained"
+            ) as load_processor,
+            patch.object(
+                flux2_image.AutoTokenizer,
+                "from_pretrained",
+                return_value=tokenizer,
+            ) as load_tokenizer,
+        ):
+            pipe = self._load_pipeline(pool, config)
+
+        self.assertTrue(config.downloaded)
+        self.assertIs(pipe.tokenizer, tokenizer)
+        load_processor.assert_not_called()
+        load_tokenizer.assert_called_once_with(config.path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- restore `AutoProcessor` loading for the Mistral3 text encoder used by FLUX.2-dev
- retain `AutoTokenizer` for the Qwen3 text encoder used by FLUX.2 Klein
- add CPU regression tests for both model-family paths

## Problem

The original FLUX.2-dev integration loaded its tokenizer directory through `AutoProcessor`. When Klein/Qwen3 support was added, the shared loader was changed to `AutoTokenizer` unconditionally.

FLUX.2-dev passes structured multimodal-style message content to `apply_chat_template`:

```python
{"content": [{"type": "text", "text": prompt}]}
```

The Mistral3 path requires its processor to normalize that structure before tokenization. Calling the bare tokenizer diverges from both reference implementations:

- [Black Forest Labs FLUX.2](https://github.com/black-forest-labs/flux2/blob/5a5d316b1b42f6b59a8c9194b77c8256be848432/src/flux2/text_encoder.py#L35-L40)
- [Hugging Face Diffusers FLUX.2](https://github.com/huggingface/diffusers/blob/1b98ae1060b765f2efe22540f52691b8c00a83f1/src/diffusers/pipelines/flux2/pipeline_flux2.py#L304-L332)

This explains why FLUX.2-dev prompt handling regressed while the Qwen3/Klein path still required a tokenizer.

## Fix

Select the loader from the text encoder actually present in the model pool:

- Mistral3 / FLUX.2-dev -> `AutoProcessor`
- Qwen3 / FLUX.2 Klein -> `AutoTokenizer`

If both are absent, the default FLUX.2-dev configuration continues to use `AutoProcessor`.

## Validation

- baseline current main: Mistral3 processor-selection test fails; Qwen3 tokenizer test passes
- after this change: 2 tests pass
- `python -B -m unittest discover -s tests -p test_flux2_tokenizer_selection.py -v`
- Python compilation passes for both changed files
- Ruff passes for the new test and the new production path after excluding ten unrelated pre-existing findings in the legacy pipeline file
- `git diff --check` passes

I could not run the gated FLUX.2-dev checkpoint end to end, so this PR claims restoration of the official prompt-processing path rather than an image-level parity measurement.

Closes #1324