### PR TITLE
fix cycle-ref bug for bnb backend

### DIFF
--- a/diffsynth/core/quant/backends/bitsandbytes.py
+++ b/diffsynth/core/quant/backends/bitsandbytes.py
@@ -11,26 +11,27 @@ except ImportError:
     BITSANDBYTES_AVAILABLE = False
 
 
-def _assign_params_from_state_dict(self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs):
-    """`_load_from_state_dict` replacement for shells: assigns tensors as-is, since packed weights do not pass the standard shape check."""
-    local_names = set()
-    for name, current in list(self._parameters.items()) + list(self._buffers.items()):
-        if current is None:
-            continue
-        local_names.add(name)
-        key = prefix + name
-        if key in state_dict:
-            value = state_dict[key]
-            if name in self._parameters:
-                self._parameters[name] = value if isinstance(value, torch.nn.Parameter) else torch.nn.Parameter(value, requires_grad=False)
-            else:
-                self._buffers[name] = value
-        elif strict:
-            missing_keys.append(key)
-    if strict:
-        for key in state_dict:
-            if key.startswith(prefix) and key[len(prefix):].split(".", 1)[0] not in local_names:
-                unexpected_keys.append(key)
+if BITSANDBYTES_AVAILABLE:
+    class BitsAndBytesLinear4bit(bnb.nn.Linear4bit):
+        def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs):
+            local_names = set()
+            for name, current in list(self._parameters.items()) + list(self._buffers.items()):
+                if current is None:
+                    continue
+                local_names.add(name)
+                key = prefix + name
+                if key in state_dict:
+                    value = state_dict[key]
+                    if name in self._parameters:
+                        self._parameters[name] = value if isinstance(value, torch.nn.Parameter) else torch.nn.Parameter(value, requires_grad=False)
+                    else:
+                        self._buffers[name] = value
+                elif strict:
+                    missing_keys.append(key)
+            if strict:
+                for key in state_dict:
+                    if key.startswith(prefix) and key[len(prefix):].split(".", 1)[0] not in local_names:
+                        unexpected_keys.append(key)
 
 
 @register_quant_backend("bitsandbytes")
@@ -55,7 +56,7 @@ class BitsAndBytesQuantBackend(QuantBackend):
         }
 
     def quantized_linear_classes(self):
-        return (bnb.nn.Linear4bit,)
+        return (BitsAndBytesLinear4bit,)
 
     def create_quantized_linear(self, linear, compute_device=None, model_device=None):
         """The `meta` shell avoids allocating an fp weight; bnb quantizes while `Params4bit` moves to `compute_device`."""
@@ -65,7 +66,7 @@ class BitsAndBytesQuantBackend(QuantBackend):
             compute_device = linear.weight.device
 
         with torch.device("meta"):
-            quant_linear = bnb.nn.Linear4bit(
+            quant_linear = BitsAndBytesLinear4bit(
                 linear.in_features,
                 linear.out_features,
                 bias=linear.bias is not None,
@@ -89,7 +90,7 @@ class BitsAndBytesQuantBackend(QuantBackend):
 
     def create_quantized_linear_shell(self, linear, compute_dtype):
         with torch.device("meta"):
-            shell = bnb.nn.Linear4bit(
+            shell = BitsAndBytesLinear4bit(
                 linear.in_features,
                 linear.out_features,
                 bias=linear.bias is not None,
@@ -98,7 +99,6 @@ class BitsAndBytesQuantBackend(QuantBackend):
                 quant_type=self.config.quant_type,
                 quant_storage=self.config.quant_storage,
             )
-        shell._load_from_state_dict = _assign_params_from_state_dict.__get__(shell)
         return shell
 
     def unflatten_state_dict(self, state_dict, metadata):


### PR DESCRIPTION
# Fix cross-generation VRAM leak in the bitsandbytes 4bit backend

## Problem

Running MiniMax-H3 NF4 (disk offload + turbo LoRA) in a loop, the first few videos
succeed and then generation dies with `CUDA out of memory` — reported at the 5th
video on an 80GB A100 at 768x1344 / 260 frames.

The cause is how the packed-weight loader was attached to each quantized layer:

```python
shell._load_from_state_dict = _assign_params_from_state_dict.__get__(shell)
```

`func.__get__(shell)` builds a **bound method** whose `__self__` points back at the
shell, and it is stored in the shell's own `__dict__`:

```
shell -> __dict__["_load_from_state_dict"] -> bound method -> __self__ -> shell
```

That is a self-reference cycle, which reference counting can never collect. Every
offload cycle calls `build_quantized_shell` and drops the previous shell, so each
dropped `Linear4bit` — together with its packed 4bit weight — stays resident on the
GPU until a full `gc.collect()` runs.

Python's cycle collector does run eventually, but it is triggered by **object count**,
not by bytes. A `Params4bit` is a few hundred bytes of Python object holding tens of
MB of VRAM, so the collector sees "almost no garbage" while the GPU fills up. The
allocation fails long before the collector gets there.

The override itself is required: packed 4bit weights (a flat uint8 blob plus
quant-state tensors) do not match the Linear's declared `[out, in]` shape, so the
stock `_load_from_state_dict` rejects them on the shape check — `assign=True` does
not skip that check. bitsandbytes does not ship an override for this
(`Linear4bit._load_from_state_dict is torch.nn.Module._load_from_state_dict`);
transformers/accelerate avoid the problem by bypassing `load_state_dict` entirely
and assigning `Params4bit.from_prequantized(...)` per tensor. DiffSynth loads every
backend through one `load_state_dict(assign=True)` path, so it needs the override.

## Fix

Move the override from the instance to the **class**: a `BitsAndBytesLinear4bit`
subclass of `bnb.nn.Linear4bit` defines `_load_from_state_dict` directly. Method
lookup binds on attribute access and discards the bound method afterwards, so
nothing is stored on the instance and no cycle forms. The backend now produces this
one type for both real quantized layers and offload shells, and
`quantized_linear_classes()` declares it, so the model stays a single consistent type.

## Evidence

Measured on one A100-80GB, `torch 2.11.0+cu128`, `bitsandbytes 0.50.0`.

**Micro (one real CUDA NF4 layer, dropped with GC disabled)**

| override style | freed by refcount | VRAM after `del` |
|---|---|---|
| instance bound method (before) | No | 2.1 MB → 2.1 MB |
| class-level subclass (after) | Yes | 2.1 MB → 0.0 MB |

**GC audit after one generation** (`gc.DEBUG_SAVEALL`, MiniMax-H3 NF4)

- before: 4363 CUDA tensors trapped in cycles, **22.5 GiB**; object types
  `854 Linear4bit / 854 Params4bit / 854 method / 1708 QuantState`
- after: **0 CUDA tensors, 0 GiB**

**End to end, MiniMax-H3 NF4, 768x1344 / 260 frames, no manual cleanup in the loop**

| | before | after |
|---|---|---|
| residual `alloc` per generation | 24.6 → 15.9 → 38.5 GiB (accumulating) | flat 2.018 GiB |
| peak `reserved` | 44.5 → 62.3 GiB (rising) | flat ~32 GiB |
| outcome | **OOM on the 4th generation** | 10 generations, no OOM |

No user-side workaround (`del` + `gc.collect()` + `empty_cache()`) is needed anymore.

## Regression testing

Quant backend compatibility matrix on Z-Image Turbo, for **every method this backend
registers**:

| method | C0 | C1 | C2 | C3 | C4 | C5 | C6 | C7 |
|---|---|---|---|---|---|---|---|---|
| bitsandbytes_nf4 | PASS | PASS | PASS | PASS | N/A | PASS | PASS | PASS |
| bitsandbytes_fp4 | PASS | PASS | PASS | PASS | N/A | PASS | PASS | PASS |

C3 round-trip and C5/C6 offload transparency are bit-identical (`inf dB`), so
serialization and VRAM management are unchanged. C7 confirms quant training still
works (`adapter_grads=True, base_frozen=True`). C4 is N/A only because no external
checkpoint was supplied. Rendered images were also reviewed by eye, not just by PSNR.

Beyond the matrix cells:

- **Online-quant LoRA training** (Z-Image Turbo, `--quant_options bitsandbytes_nf4`):
  528 Linear layers quantized online, training ran clean, and a validation render with
  the adapter loaded differs from the un-adapted render (34.11 dB, not `inf`), i.e. the
  adapter is really applied rather than silently ignored.
- **Prequantized inference** on the model's own NF4 checkpoint via
  `examples/minimax_h3/model_inference_low_vram/MiniMax-H3-NF4-FL2VA.py`.

## Notes

- `quantized_linear_classes()` now returns `(BitsAndBytesLinear4bit,)`. All
  recognition paths (`prepare_for_prequantized_load`, `build_quantized_shell`) are fed
  by this backend's own factories, and the in-repo `check_backend_contract` self-test
  passes, including "the shell is recognized before load_state_dict".
- The other backends (`torchao`, `comfy_kitchen`) build proper subclasses and never
  used the instance-bound-method pattern, so they are unaffected.
- Unrelated pre-existing limitation observed while testing: on a quantized model,
  `load_lora` must hot-load, since fusing a LoRA into a packed NF4 weight is a shape
  mismatch. Hot-loading requires VRAM management to be enabled.
