### PR TITLE
feat: add CFG-aware fine-tuning loss for MiniMax-H3

### DIFF
--- a/diffsynth/diffusion/loss.py
+++ b/diffsynth/diffusion/loss.py
@@ -63,7 +63,12 @@ def FlowMatchSFTAudioVideoLoss(pipe: BasePipeline, **inputs):
     return loss
 
 
-def FlowMatchSFTMiniMaxH3AudioVideoLoss(pipe: BasePipeline, **inputs):
+def FlowMatchSFTMiniMaxH3AudioVideoLoss(
+    pipe: BasePipeline,
+    training_cfg_scale: float = 1.0,
+    inputs_nega: dict | None = None,
+    **inputs,
+):
     max_timestep_boundary = int(inputs.get("max_timestep_boundary", 1) * len(pipe.scheduler.timesteps))
     min_timestep_boundary = int(inputs.get("min_timestep_boundary", 0) * len(pipe.scheduler.timesteps))
 
@@ -81,10 +86,37 @@ def FlowMatchSFTMiniMaxH3AudioVideoLoss(pipe: BasePipeline, **inputs):
         training_target_audio = pipe.scheduler_audio.training_target(inputs["audio_input_latents"], audio_noise, timestep_audio)
 
     models = {name: getattr(pipe, name) for name in pipe.in_iteration_models}
+    if training_cfg_scale > 1.0:
+        if not inputs_nega:
+            raise ValueError(
+                "MiniMax-H3 CFG-aware training requires unconditional inputs. "
+                "When using split training, rebuild the data cache with the same "
+                "--training_cfg_scale value."
+            )
+        inputs_uncond = {**inputs, **inputs_nega}
+        inputs_uncond["use_gradient_checkpointing"] = False
+        inputs_uncond["use_gradient_checkpointing_offload"] = False
+        with torch.no_grad():
+            noise_pred_uncond, noise_pred_audio_uncond = pipe.model_fn(
+                **models, **inputs_uncond,
+                timestep_video=timestep_video, timestep_audio=timestep_audio,
+            )
+
     noise_pred, noise_pred_audio = pipe.model_fn(
         **models, **inputs,
         timestep_video=timestep_video, timestep_audio=timestep_audio,
     )
+
+    if training_cfg_scale > 1.0:
+        # The checkpoint's conditional prediction has CFG distilled into it.
+        # Rearrange the CFG equation to recover the raw velocity fitted to the
+        # standard flow-matching target, using the current model as the teacher.
+        noise_pred = (
+            noise_pred + (training_cfg_scale - 1.0) * noise_pred_uncond
+        ) / training_cfg_scale
+        noise_pred_audio = (
+            noise_pred_audio + (training_cfg_scale - 1.0) * noise_pred_audio_uncond
+        ) / training_cfg_scale
 
     loss = torch.nn.functional.mse_loss(noise_pred.float(), training_target.float())
     loss = loss * pipe.scheduler.training_weight(timestep_video)

--- a/diffsynth/diffusion/loss.py
+++ b/diffsynth/diffusion/loss.py
@@ -63,12 +63,7 @@ def FlowMatchSFTAudioVideoLoss(pipe: BasePipeline, **inputs):
     return loss
 
 
-def FlowMatchSFTMiniMaxH3AudioVideoLoss(
-    pipe: BasePipeline,
-    training_cfg_scale: float = 1.0,
-    inputs_nega: dict | None = None,
-    **inputs,
-):
+def FlowMatchSFTMiniMaxH3AudioVideoLoss(pipe: BasePipeline, training_cfg_scale: float = 1.0, inputs_nega: dict | None = None, **inputs):
     max_timestep_boundary = int(inputs.get("max_timestep_boundary", 1) * len(pipe.scheduler.timesteps))
     min_timestep_boundary = int(inputs.get("min_timestep_boundary", 0) * len(pipe.scheduler.timesteps))
 
@@ -111,12 +106,8 @@ def FlowMatchSFTMiniMaxH3AudioVideoLoss(
         # The checkpoint's conditional prediction has CFG distilled into it.
         # Rearrange the CFG equation to recover the raw velocity fitted to the
         # standard flow-matching target, using the current model as the teacher.
-        noise_pred = (
-            noise_pred + (training_cfg_scale - 1.0) * noise_pred_uncond
-        ) / training_cfg_scale
-        noise_pred_audio = (
-            noise_pred_audio + (training_cfg_scale - 1.0) * noise_pred_audio_uncond
-        ) / training_cfg_scale
+        noise_pred = (noise_pred + (training_cfg_scale - 1.0) * noise_pred_uncond) / training_cfg_scale
+        noise_pred_audio = (noise_pred_audio + (training_cfg_scale - 1.0) * noise_pred_audio_uncond) / training_cfg_scale
 
     loss = torch.nn.functional.mse_loss(noise_pred.float(), training_target.float())
     loss = loss * pipe.scheduler.training_weight(timestep_video)

--- a/examples/minimax_h3/model_training/lora/MiniMax-H3-FL2VA.sh
+++ b/examples/minimax_h3/model_training/lora/MiniMax-H3-FL2VA.sh
@@ -1,5 +1,7 @@
 modelscope download --dataset DiffSynth-Studio/diffsynth_example_dataset --include "minimax_h3/MiniMax-H3-FL2VA/*" --local_dir ./data/diffsynth_example_dataset
 
+# Optional: add `--training_cfg_scale 4` to both stages below to enable CFG-aware training.
+# Both stages must use the same value because the unconditional embeddings are cached in stage 1.
 # T2VA - stage 1 (data process)
 accelerate launch examples/minimax_h3/model_training/train.py \
   --dataset_base_path data/diffsynth_example_dataset/minimax_h3/MiniMax-H3-FL2VA \

--- a/examples/minimax_h3/model_training/lora/MiniMax-H3-FL2VA.sh
+++ b/examples/minimax_h3/model_training/lora/MiniMax-H3-FL2VA.sh
@@ -1,7 +1,12 @@
 modelscope download --dataset DiffSynth-Studio/diffsynth_example_dataset --include "minimax_h3/MiniMax-H3-FL2VA/*" --local_dir ./data/diffsynth_example_dataset
 
-# Optional: add `--training_cfg_scale 4` to both stages below to enable CFG-aware training.
-# Both stages must use the same value because the unconditional embeddings are cached in stage 1.
+# Optional
+# 1. Fuse the DeCFG training adapter into the DiT while training, for a better optimization landscape on this CFG-distilled base. Training only -- do not load it at inference.
+# modelscope download --model DiffSynth-Studio/MiniMax-H3-TrainingAdapter --local_dir ./models/DiffSynth-Studio/MiniMax-H3-TrainingAdapter
+#   --preset_lora_path "./models/DiffSynth-Studio/MiniMax-H3-TrainingAdapter/model.safetensors" \
+#   --preset_lora_model "dit"
+# 2. Add `--training_cfg_scale 4` to both stages below to enable CFG-aware training. Both stages must use the same value because the unconditional embeddings are cached in stage 1.
+
 # T2VA - stage 1 (data process)
 accelerate launch examples/minimax_h3/model_training/train.py \
   --dataset_base_path data/diffsynth_example_dataset/minimax_h3/MiniMax-H3-FL2VA \
@@ -43,10 +48,6 @@ accelerate launch examples/minimax_h3/model_training/train.py \
   --use_gradient_checkpointing \
   --find_unused_parameters \
   --task "sft:train"
-# Optional: fuse the DeCFG training adapter into the DiT while training, for a better optimization landscape on this CFG-distilled base. Training only -- do not load it at inference.
-# modelscope download --model DiffSynth-Studio/MiniMax-H3-TrainingAdapter --local_dir ./models/DiffSynth-Studio/MiniMax-H3-TrainingAdapter
-#   --preset_lora_path "./models/DiffSynth-Studio/MiniMax-H3-TrainingAdapter/model.safetensors" \
-#   --preset_lora_model "dit"
 
 # input_image / end_image take the first and last frame of the training video
 # FL2VA - stage 1 (data process)

--- a/examples/minimax_h3/model_training/train.py
+++ b/examples/minimax_h3/model_training/train.py
@@ -28,10 +28,14 @@ class MiniMaxH3TrainingModule(DiffusionTrainingModule):
         template_model_id_or_path=None,
         resume_from_checkpoint=None, remove_prefix_in_ckpt=None,
         silent_on_missing_audio=False,
+        training_cfg_scale=1.0,
         device="cpu",
         task="sft",
     ):
         super().__init__()
+        if training_cfg_scale < 1.0:
+            raise ValueError("training_cfg_scale must be at least 1.0")
+        self.training_cfg_scale = training_cfg_scale
         # Load models
         model_configs = self.parse_model_configs(model_paths, model_id_with_origin_paths, fp8_models=fp8_models, offload_models=offload_models, quant_options=quant_options, device=device)
         pipe_kwargs = {}
@@ -43,7 +47,7 @@ class MiniMaxH3TrainingModule(DiffusionTrainingModule):
             task, self.pipe, trainable_models, lora_base_model,
             remove_unnecessary_params=True,
             force_remove_params_shared=("video_latents", "audio_latents"),
-            force_remove_params_nega=("prompt_embeds", "text_token_tags", "packed"),
+            force_remove_params_nega=("prompt_embeds", "text_token_tags", "packed") if training_cfg_scale == 1.0 else (),
         )
         self.resume_from_checkpoint(resume_from_checkpoint, remove_prefix_in_ckpt)
         # Training mode
@@ -64,8 +68,12 @@ class MiniMaxH3TrainingModule(DiffusionTrainingModule):
         self.task = task
         self.task_to_loss = {
             "sft:data_process": lambda pipe, *args: args,
-            "sft": lambda pipe, inputs_shared, inputs_posi, inputs_nega: FlowMatchSFTMiniMaxH3AudioVideoLoss(pipe, **inputs_shared, **inputs_posi),
-            "sft:train": lambda pipe, inputs_shared, inputs_posi, inputs_nega: FlowMatchSFTMiniMaxH3AudioVideoLoss(pipe, **inputs_shared, **inputs_posi),
+            "sft": lambda pipe, inputs_shared, inputs_posi, inputs_nega: FlowMatchSFTMiniMaxH3AudioVideoLoss(
+                pipe, training_cfg_scale=self.training_cfg_scale, inputs_nega=inputs_nega, **inputs_shared, **inputs_posi,
+            ),
+            "sft:train": lambda pipe, inputs_shared, inputs_posi, inputs_nega: FlowMatchSFTMiniMaxH3AudioVideoLoss(
+                pipe, training_cfg_scale=self.training_cfg_scale, inputs_nega=inputs_nega, **inputs_shared, **inputs_posi,
+            ),
         }
 
     def parse_extra_inputs(self, data, extra_inputs, inputs_shared):
@@ -93,7 +101,7 @@ class MiniMaxH3TrainingModule(DiffusionTrainingModule):
 
     def get_pipeline_inputs(self, data):
         inputs_posi = {"prompt": data["prompt"]}
-        inputs_nega = {}
+        inputs_nega = {"negative_prompt": " "}
         inputs_shared = {
             # Assume you are using this pipeline for inference,
             # please fill in the input parameters.
@@ -110,7 +118,9 @@ class MiniMaxH3TrainingModule(DiffusionTrainingModule):
             "audio_cond_noise_aug": self.pipe.audio_cond_noise_aug,
             # Please do not modify the following parameters
             # unless you clearly know what this will cause.
-            "cfg_scale": 1,
+            # Reuse the pipeline's CFG preprocessing path to build unconditional
+            # embeddings when CFG-aware training is enabled.
+            "cfg_scale": self.training_cfg_scale,
             "seed": 42,
             "rand_device": "cpu",
             "use_gradient_checkpointing": self.use_gradient_checkpointing,
@@ -135,6 +145,7 @@ def minimax_h3_parser():
     parser.add_argument("--processor_path", type=str, default=None, help="Path or `model_id:pattern` of the Qwen3-VL processor.")
     parser.add_argument("--initialize_model_on_cpu", default=False, action="store_true", help="Whether to initialize models on CPU.")
     parser.add_argument("--silent_on_missing_audio", default=False, action="store_true", help="Whether to use silent audio as a fallback when no audio track is present in the video data.")
+    parser.add_argument("--training_cfg_scale", type=float, default=1.0, help="Inverse-CFG scale for preserving MiniMax-H3 guidance distillation during fine-tuning. Values greater than 1 enable a no-grad unconditional branch; 1 keeps the standard flow-matching loss.")
     return parser
 
 
@@ -208,6 +219,7 @@ if __name__ == "__main__":
         resume_from_checkpoint=args.resume_from_checkpoint,
         remove_prefix_in_ckpt=args.remove_prefix_in_ckpt,
         silent_on_missing_audio=args.silent_on_missing_audio,
+        training_cfg_scale=args.training_cfg_scale,
         task=args.task,
         device="cpu" if (args.initialize_model_on_cpu or args.enable_model_cpu_offload) else accelerator.device,
     )


### PR DESCRIPTION
## Motivation

MiniMax-H3 checkpoints are CFG-distilled. In #1557, a maintainer and several users discuss that longer SFT may weaken the model's built-in guidance distillation, while enabling CFG only at inference may not fully recover the base model behavior.

This PR adds an optional CFG-aware fine-tuning objective designed to mitigate this degradation. The approach is inspired by the [CFG-augmented training implementation in `tdrussell/diffusion-pipe`](https://github.com/tdrussell/diffusion-pipe/blob/8f83dbf25d03219df705570ec03e62be04bc402f/models/minimax_h3.py#L740-L742) and adapted to DiffSynth-Studio's joint audio-video loss and split-training pipeline.

## Method

When `training_cfg_scale = s > 1`, the current model produces:

- a conditional prediction $v_{\mathrm{cond}}$ with gradients;
- an unconditional prediction $v_{\mathrm{uncond}}$ under `torch.no_grad()`.

Both predictions use the same noisy latents and timesteps. The prediction fitted to the standard flow-matching target is reconstructed by rearranging the CFG equation:

$v_{\mathrm{raw}} = \frac{v_{\mathrm{cond}} + (s - 1)v_{\mathrm{uncond}}}{s}$

The same operation is applied to both video and audio predictions.

## Changes

- Add `--training_cfg_scale`, defaulting to `1.0`.
- Preserve the existing flow-matching path when the value is `1.0`.
- Run a current-model, no-grad unconditional forward when the value is greater than `1.0`.
- Generate and retain unconditional prompt inputs for regular and split training.
- Report a clear error when a split-training cache does not contain the required unconditional inputs.
- Document how to enable CFG-aware training in the MiniMax-H3 LoRA example.

## Backward compatibility

The default value is `1.0`, so existing training commands retain the previous loss and do not incur an additional model forward.

CFG-aware training is opt-in. For split training, the same `training_cfg_scale` must be used in both stages. Existing caches generated without unconditional inputs must be rebuilt before enabling it.

Related to #1557.