### PR TITLE
# Add --audio_loss_weight to MiniMax-H3 training

### DIFF
--- a/diffsynth/diffusion/loss.py
+++ b/diffsynth/diffusion/loss.py
@@ -63,7 +63,7 @@ def FlowMatchSFTAudioVideoLoss(pipe: BasePipeline, **inputs):
     return loss
 
 
-def FlowMatchSFTMiniMaxH3AudioVideoLoss(pipe: BasePipeline, training_cfg_scale: float = 1.0, inputs_nega: dict | None = None, **inputs):
+def FlowMatchSFTMiniMaxH3AudioVideoLoss(pipe: BasePipeline, training_cfg_scale: float = 1.0, audio_loss_weight: float = 1.0, inputs_nega: dict | None = None, **inputs):
     max_timestep_boundary = int(inputs.get("max_timestep_boundary", 1) * len(pipe.scheduler.timesteps))
     min_timestep_boundary = int(inputs.get("min_timestep_boundary", 0) * len(pipe.scheduler.timesteps))
 
@@ -113,7 +113,7 @@ def FlowMatchSFTMiniMaxH3AudioVideoLoss(pipe: BasePipeline, training_cfg_scale: 
     loss = loss * pipe.scheduler.training_weight(timestep_video)
     if "audio_input_latents" in inputs:
         loss_audio = torch.nn.functional.mse_loss(noise_pred_audio.float(), training_target_audio.float())
-        loss_audio = loss_audio * pipe.scheduler_audio.training_weight(timestep_audio)
+        loss_audio = loss_audio * pipe.scheduler_audio.training_weight(timestep_audio) * audio_loss_weight
         loss = loss + loss_audio
     return loss
 

--- a/docs/en/Model_Details/MiniMax-H3.md
+++ b/docs/en/Model_Details/MiniMax-H3.md
@@ -211,6 +211,10 @@ Models in the MiniMax-H3 series are trained uniformly via [`examples/minimax_h3/
 * MiniMax-H3 Specific Parameters
     * `--processor_path`: Path of the Qwen3-VL processor, supports the `model_id:origin_file_pattern` form, used to tokenize the prompt.
     * `--initialize_model_on_cpu`: Whether to initialize models on CPU.
+    * `--silent_on_missing_audio`: Whether to use silent audio as a fallback when no audio track is present in the video data.
+    * `--reference_max_pixels`: Maximum number of pixels per frame for reference videos.
+    * `--training_cfg_scale`: Inverse-CFG scale for preserving MiniMax-H3 guidance distillation during fine-tuning. Values greater than 1 enable a no-grad unconditional branch; 1 keeps the standard flow-matching loss.
+    * `--audio_loss_weight`: Weight of the audio term in the MiniMax-H3 loss. 1 keeps video and audio equally weighted; 0 trains on the video term only while the audio stream is still noised and forwarded.
 
 We provide an example dataset for testing, which can be downloaded with the following command:
 

--- a/docs/en/Model_Details/MiniMax-H3.md
+++ b/docs/en/Model_Details/MiniMax-H3.md
@@ -212,7 +212,6 @@ Models in the MiniMax-H3 series are trained uniformly via [`examples/minimax_h3/
     * `--processor_path`: Path of the Qwen3-VL processor, supports the `model_id:origin_file_pattern` form, used to tokenize the prompt.
     * `--initialize_model_on_cpu`: Whether to initialize models on CPU.
     * `--silent_on_missing_audio`: Whether to use silent audio as a fallback when no audio track is present in the video data.
-    * `--reference_max_pixels`: Maximum number of pixels per frame for reference videos.
     * `--training_cfg_scale`: Inverse-CFG scale for preserving MiniMax-H3 guidance distillation during fine-tuning. Values greater than 1 enable a no-grad unconditional branch; 1 keeps the standard flow-matching loss.
     * `--audio_loss_weight`: Weight of the audio term in the MiniMax-H3 loss. 1 keeps video and audio equally weighted; 0 trains on the video term only while the audio stream is still noised and forwarded.
 

--- a/docs/zh/Model_Details/MiniMax-H3.md
+++ b/docs/zh/Model_Details/MiniMax-H3.md
@@ -212,7 +212,6 @@ MiniMax-H3 系列模型统一通过 [`examples/minimax_h3/model_training/train.p
     * `--processor_path`: Qwen3-VL processor 的路径，支持 `model_id:origin_file_pattern` 形式，用于对 prompt 进行 tokenize。
     * `--initialize_model_on_cpu`: 是否在 CPU 上初始化模型。
     * `--silent_on_missing_audio`: 视频数据不含音轨时，是否以静音音频作为兜底。
-    * `--reference_max_pixels`: 参考视频每帧的最大像素数。
     * `--training_cfg_scale`: 微调时用于保留 MiniMax-H3 指导蒸馏的逆 CFG 系数。大于 1 时启用一路无梯度的无条件分支，等于 1 时保持标准 flow matching 损失。
     * `--audio_loss_weight`: MiniMax-H3 损失中音频项的权重。为 1 时视频与音频等权重，为 0 时只用视频项训练，音频流仍会加噪并送入模型。
 

--- a/docs/zh/Model_Details/MiniMax-H3.md
+++ b/docs/zh/Model_Details/MiniMax-H3.md
@@ -211,6 +211,10 @@ MiniMax-H3 系列模型统一通过 [`examples/minimax_h3/model_training/train.p
 * MiniMax-H3 专有参数
     * `--processor_path`: Qwen3-VL processor 的路径，支持 `model_id:origin_file_pattern` 形式，用于对 prompt 进行 tokenize。
     * `--initialize_model_on_cpu`: 是否在 CPU 上初始化模型。
+    * `--silent_on_missing_audio`: 视频数据不含音轨时，是否以静音音频作为兜底。
+    * `--reference_max_pixels`: 参考视频每帧的最大像素数。
+    * `--training_cfg_scale`: 微调时用于保留 MiniMax-H3 指导蒸馏的逆 CFG 系数。大于 1 时启用一路无梯度的无条件分支，等于 1 时保持标准 flow matching 损失。
+    * `--audio_loss_weight`: MiniMax-H3 损失中音频项的权重。为 1 时视频与音频等权重，为 0 时只用视频项训练，音频流仍会加噪并送入模型。
 
 我们构建了一个样例数据集，以方便您进行测试，通过以下命令可以下载这个数据集：
 

--- a/examples/minimax_h3/model_training/train.py
+++ b/examples/minimax_h3/model_training/train.py
@@ -29,6 +29,7 @@ class MiniMaxH3TrainingModule(DiffusionTrainingModule):
         resume_from_checkpoint=None, remove_prefix_in_ckpt=None,
         silent_on_missing_audio=False,
         training_cfg_scale=1.0,
+        audio_loss_weight=1.0,
         device="cpu",
         task="sft",
     ):
@@ -36,6 +37,7 @@ class MiniMaxH3TrainingModule(DiffusionTrainingModule):
         if training_cfg_scale < 1.0:
             raise ValueError("training_cfg_scale must be at least 1.0")
         self.training_cfg_scale = training_cfg_scale
+        self.audio_loss_weight = audio_loss_weight
         # Load models
         model_configs = self.parse_model_configs(model_paths, model_id_with_origin_paths, fp8_models=fp8_models, offload_models=offload_models, quant_options=quant_options, device=device)
         pipe_kwargs = {}
@@ -69,10 +71,12 @@ class MiniMaxH3TrainingModule(DiffusionTrainingModule):
         self.task_to_loss = {
             "sft:data_process": lambda pipe, *args: args,
             "sft": lambda pipe, inputs_shared, inputs_posi, inputs_nega: FlowMatchSFTMiniMaxH3AudioVideoLoss(
-                pipe, training_cfg_scale=self.training_cfg_scale, inputs_nega=inputs_nega, **inputs_shared, **inputs_posi,
+                pipe, training_cfg_scale=self.training_cfg_scale, audio_loss_weight=self.audio_loss_weight,
+                inputs_nega=inputs_nega, **inputs_shared, **inputs_posi,
             ),
             "sft:train": lambda pipe, inputs_shared, inputs_posi, inputs_nega: FlowMatchSFTMiniMaxH3AudioVideoLoss(
-                pipe, training_cfg_scale=self.training_cfg_scale, inputs_nega=inputs_nega, **inputs_shared, **inputs_posi,
+                pipe, training_cfg_scale=self.training_cfg_scale, audio_loss_weight=self.audio_loss_weight,
+                inputs_nega=inputs_nega, **inputs_shared, **inputs_posi,
             ),
         }
 
@@ -146,6 +150,7 @@ def minimax_h3_parser():
     parser.add_argument("--initialize_model_on_cpu", default=False, action="store_true", help="Whether to initialize models on CPU.")
     parser.add_argument("--silent_on_missing_audio", default=False, action="store_true", help="Whether to use silent audio as a fallback when no audio track is present in the video data.")
     parser.add_argument("--training_cfg_scale", type=float, default=1.0, help="Inverse-CFG scale for preserving MiniMax-H3 guidance distillation during fine-tuning. Values greater than 1 enable a no-grad unconditional branch; 1 keeps the standard flow-matching loss.")
+    parser.add_argument("--audio_loss_weight", type=float, default=1.0, help="Weight of the audio term in the MiniMax-H3 loss. 1 keeps video and audio equally weighted; 0 trains on the video term only while the audio stream is still noised and forwarded.")
     return parser
 
 
@@ -220,6 +225,7 @@ if __name__ == "__main__":
         remove_prefix_in_ckpt=args.remove_prefix_in_ckpt,
         silent_on_missing_audio=args.silent_on_missing_audio,
         training_cfg_scale=args.training_cfg_scale,
+        audio_loss_weight=args.audio_loss_weight,
         task=args.task,
         device="cpu" if (args.initialize_model_on_cpu or args.enable_model_cpu_offload) else accelerator.device,
     )

--- a/examples/minimax_h3/model_training/train.py
+++ b/examples/minimax_h3/model_training/train.py
@@ -149,6 +149,7 @@ def minimax_h3_parser():
     parser.add_argument("--processor_path", type=str, default=None, help="Path or `model_id:pattern` of the Qwen3-VL processor.")
     parser.add_argument("--initialize_model_on_cpu", default=False, action="store_true", help="Whether to initialize models on CPU.")
     parser.add_argument("--silent_on_missing_audio", default=False, action="store_true", help="Whether to use silent audio as a fallback when no audio track is present in the video data.")
+    parser.add_argument("--reference_max_pixels", type=int, default=768 * 1344, help="Maximum number of pixels per frame for reference videos.")
     parser.add_argument("--training_cfg_scale", type=float, default=1.0, help="Inverse-CFG scale for preserving MiniMax-H3 guidance distillation during fine-tuning. Values greater than 1 enable a no-grad unconditional branch; 1 keeps the standard flow-matching loss.")
     parser.add_argument("--audio_loss_weight", type=float, default=1.0, help="Weight of the audio term in the MiniMax-H3 loss. 1 keeps video and audio equally weighted; 0 trains on the video term only while the audio stream is still noised and forwarded.")
     return parser
@@ -195,9 +196,7 @@ if __name__ == "__main__":
             ),
             "references": MiniMaxH3ReferenceLoader(
                 base_path=args.dataset_base_path,
-                height=args.height,
-                width=args.width,
-                max_pixels=args.max_pixels,
+                max_pixels=args.reference_max_pixels,
                 num_frames=args.num_frames,
                 frame_rate=MINIMAX_H3_FRAME_RATE,
             ),

--- a/examples/minimax_h3/model_training/train.py
+++ b/examples/minimax_h3/model_training/train.py
@@ -149,7 +149,6 @@ def minimax_h3_parser():
     parser.add_argument("--processor_path", type=str, default=None, help="Path or `model_id:pattern` of the Qwen3-VL processor.")
     parser.add_argument("--initialize_model_on_cpu", default=False, action="store_true", help="Whether to initialize models on CPU.")
     parser.add_argument("--silent_on_missing_audio", default=False, action="store_true", help="Whether to use silent audio as a fallback when no audio track is present in the video data.")
-    parser.add_argument("--reference_max_pixels", type=int, default=768 * 1344, help="Maximum number of pixels per frame for reference videos.")
     parser.add_argument("--training_cfg_scale", type=float, default=1.0, help="Inverse-CFG scale for preserving MiniMax-H3 guidance distillation during fine-tuning. Values greater than 1 enable a no-grad unconditional branch; 1 keeps the standard flow-matching loss.")
     parser.add_argument("--audio_loss_weight", type=float, default=1.0, help="Weight of the audio term in the MiniMax-H3 loss. 1 keeps video and audio equally weighted; 0 trains on the video term only while the audio stream is still noised and forwarded.")
     return parser
@@ -196,7 +195,9 @@ if __name__ == "__main__":
             ),
             "references": MiniMaxH3ReferenceLoader(
                 base_path=args.dataset_base_path,
-                max_pixels=args.reference_max_pixels,
+                height=args.height,
+                width=args.width,
+                max_pixels=args.max_pixels,
                 num_frames=args.num_frames,
                 frame_rate=MINIMAX_H3_FRAME_RATE,
             ),


### PR DESCRIPTION
# Add --audio_loss_weight to MiniMax-H3 training

> Title 用上面这一行（去掉开头的 `# `）；正文从下面 `## Summary` 开始复制。

## Summary

Adds a `--audio_loss_weight` option to MiniMax-H3 training so the audio term of the audio-video loss can be scaled independently of the video term.

MiniMax-H3 optimizes video and audio jointly with equal weight. When fine-tuning for a purely visual objective (character identity, style, motion), the audio term contributes gradients that are irrelevant to the target and can slow down or destabilize convergence. Until now the only way to avoid this was to edit `FlowMatchSFTMiniMaxH3AudioVideoLoss` by hand.

## `--audio_loss_weight`

Scales the audio MSE term after the scheduler's training weight is applied:

```python
loss_audio = loss_audio * pipe.scheduler_audio.training_weight(timestep_audio) * audio_loss_weight
```

- Default `1.0` — video and audio are equally weighted, i.e. numerically identical to the current behaviour.
- `0.0` — trains on the video term only. The audio stream is still noised and forwarded through the model, so the graph and tensor shapes are unchanged; only its gradient contribution is removed.
- Any other positive value re-balances the two terms.

Example:

```bash
accelerate launch examples/minimax_h3/model_training/train.py \
  ... \
  --audio_loss_weight 0
```

The weight is passed to the loss function from both the `sft` and `sft:train` branches of `task_to_loss`, so it works for single-stage training as well as for the second stage of split (`sft:data_process` + `sft:train`) training. It is a module-level setting rather than a data field, so it never enters the cached inputs — enabling or changing it does not require regenerating the data cache produced by `sft:data_process`.

## Documentation

Documents the new option in `docs/zh/Model_Details/MiniMax-H3.md` and `docs/en/Model_Details/MiniMax-H3.md`. While there, two pre-existing MiniMax-H3 options that were missing from the parameter list are documented as well: `--silent_on_missing_audio` and `--training_cfg_scale`. All wording is taken verbatim from the corresponding `argparse` help strings so the docs and the CLI stay in sync.

## Changed files

| File | Change |
| --- | --- |
| `diffsynth/diffusion/loss.py` | `FlowMatchSFTMiniMaxH3AudioVideoLoss` accepts `audio_loss_weight` and applies it to the audio term |
| `examples/minimax_h3/model_training/train.py` | `--audio_loss_weight` CLI option, plumbed through `MiniMaxH3TrainingModule` into both `sft` and `sft:train` loss calls |
| `docs/en/Model_Details/MiniMax-H3.md` | Document `--audio_loss_weight`, `--silent_on_missing_audio`, `--training_cfg_scale` |
| `docs/zh/Model_Details/MiniMax-H3.md` | Same, Chinese |

## Compatibility

No behaviour change by default. `audio_loss_weight` defaults to `1.0` in both the CLI and the loss function signature, so existing scripts, configs and data caches keep working unmodified.
