### PR TITLE
Fix model path in Qwen-Image-Distill-DMD2 examples

### DIFF
--- a/examples/qwen_image/model_inference/Qwen-Image-Distill-DMD2.py
+++ b/examples/qwen_image/model_inference/Qwen-Image-Distill-DMD2.py
@@ -15,7 +15,7 @@ pipe = QwenImagePipeline.from_pretrained(
     tokenizer_config=ModelConfig(model_id="Qwen/Qwen-Image", origin_file_pattern="tokenizer/"),
 )
 
-snapshot_download("MusePublic/Qwen-Image-Distill", allow_file_pattern="qwen_image_distill_3step.safetensors", cache_dir="models")
+snapshot_download("MusePublic/Qwen-Image-Distill", allow_file_pattern="qwen_image_distill_3step.safetensors", local_dir="models/MusePublic/Qwen-Image-Distill")
 lora_state_dict = load_state_dict("models/MusePublic/Qwen-Image-Distill/qwen_image_distill_3step.safetensors")
 lora_state_dict = {i.replace("base_model.model.", ""): j for i, j in lora_state_dict.items()}
 pipe.load_lora(pipe.dit, state_dict=lora_state_dict)

--- a/examples/qwen_image/model_inference_low_vram/Qwen-Image-Distill-DMD2.py
+++ b/examples/qwen_image/model_inference_low_vram/Qwen-Image-Distill-DMD2.py
@@ -26,7 +26,7 @@ pipe = QwenImagePipeline.from_pretrained(
     vram_limit=torch.cuda.mem_get_info("cuda")[1] / (1024 ** 3) - 0.5,
 )
 
-snapshot_download("MusePublic/Qwen-Image-Distill", allow_file_pattern="qwen_image_distill_3step.safetensors", cache_dir="models")
+snapshot_download("MusePublic/Qwen-Image-Distill", allow_file_pattern="qwen_image_distill_3step.safetensors", local_dir="models/MusePublic/Qwen-Image-Distill")
 lora_state_dict = load_state_dict("models/MusePublic/Qwen-Image-Distill/qwen_image_distill_3step.safetensors", device="cuda", torch_dtype=torch.bfloat16)
 lora_state_dict = {i.replace("base_model.model.", "").replace(".weight", ".default.weight"): j for i, j in lora_state_dict.items()}
 pipe.load_lora(pipe.dit, state_dict=lora_state_dict, hotload=True)


### PR DESCRIPTION
Thanks for this project — I've been working through the `examples/qwen_image/` scripts and hit a few small things; this is the most clear-cut one.

Both `Qwen-Image-Distill-DMD2.py` examples download the distill LoRA into one directory layout and read it back from another, so the load fails.

[`model_inference/Qwen-Image-Distill-DMD2.py:18-19`](https://github.com/modelscope/DiffSynth-Studio/blob/4dbf980d4d0eb34eda136300dd0d72014cff8965/examples/qwen_image/model_inference/Qwen-Image-Distill-DMD2.py#L18-L19):

```python
snapshot_download("MusePublic/Qwen-Image-Distill", allow_file_pattern="qwen_image_distill_3step.safetensors", cache_dir="models")
lora_state_dict = load_state_dict("models/MusePublic/Qwen-Image-Distill/qwen_image_distill_3step.safetensors")
```

With modelscope 1.39.1, `cache_dir=` writes the hub cache layout, so the file lands at:

```
models/models/MusePublic--Qwen-Image-Distill/snapshots/master/qwen_image_distill_3step.safetensors
```

while the next line reads the `local_dir=` layout, `models/MusePublic/Qwen-Image-Distill/...`. The download reports success and the read then fails:

```
Downloading: 100%|██████████| 1/1 [00:03<00:00,  3.52s/file]
Traceback (most recent call last):
  File ".../Qwen-Image-Distill-DMD2.py", line 19, in <module>
    lora_state_dict = load_state_dict("models/MusePublic/Qwen-Image-Distill/qwen_image_distill_3step.safetensors")
FileNotFoundError: No such file or directory: models/MusePublic/Qwen-Image-Distill/qwen_image_distill_3step.safetensors
```

I first hit this during a CDN timeout and assumed that was the cause, but a clean, fully successful download fails the same way. Since the cache layout has changed across modelscope versions, I'd guess this worked when it was written.

These are the only two call sites in the repo using `cache_dir=`: of 321 `snapshot_download(...)` calls under `examples/` at `4dbf980`, 319 pass `local_dir=` and these 2 pass `cache_dir=`. The patch switches them to `local_dir=`, matching the sibling `Qwen-Image-Distill-LoRA.py:5`.

## Checking

Both scripts fail at `4dbf980` and produce an image with this patch, on 1×H100 downloading from ModelScope:

- `model_inference/Qwen-Image-Distill-DMD2.py` — 53s
- `model_inference_low_vram/Qwen-Image-Distill-DMD2.py` — 69s
