### PR TITLE
Add missing dataset download to Qwen-Image validate examples

### DIFF
--- a/examples/qwen_image/model_training/validate_full/FireRed-Image-Edit-1.0.py
+++ b/examples/qwen_image/model_training/validate_full/FireRed-Image-Edit-1.0.py
@@ -2,6 +2,7 @@ import torch
 from PIL import Image
 from diffsynth.pipelines.qwen_image import QwenImagePipeline, ModelConfig
 from diffsynth import load_state_dict
+from modelscope import dataset_snapshot_download
 
 pipe = QwenImagePipeline.from_pretrained(
     torch_dtype=torch.bfloat16,
@@ -16,6 +17,12 @@ pipe = QwenImagePipeline.from_pretrained(
 )
 state_dict = load_state_dict("models/train/FireRed-Image-Edit-1.0_full/epoch-1.safetensors")
 pipe.dit.load_state_dict(state_dict)
+
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="edit/*.jpg"
+)
 
 prompt = "Change the color of the dress in Figure 1 to the color shown in Figure 2."
 images = [

--- a/examples/qwen_image/model_training/validate_full/FireRed-Image-Edit-1.1.py
+++ b/examples/qwen_image/model_training/validate_full/FireRed-Image-Edit-1.1.py
@@ -2,6 +2,7 @@ import torch
 from PIL import Image
 from diffsynth.pipelines.qwen_image import QwenImagePipeline, ModelConfig
 from diffsynth import load_state_dict
+from modelscope import dataset_snapshot_download
 
 pipe = QwenImagePipeline.from_pretrained(
     torch_dtype=torch.bfloat16,
@@ -16,6 +17,12 @@ pipe = QwenImagePipeline.from_pretrained(
 )
 state_dict = load_state_dict("models/train/FireRed-Image-Edit-1.1_full/epoch-1.safetensors")
 pipe.dit.load_state_dict(state_dict)
+
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="edit/*.jpg"
+)
 
 prompt = "Change the color of the dress in Figure 1 to the color shown in Figure 2."
 images = [

--- a/examples/qwen_image/model_training/validate_full/Qwen-Image-Edit-2509.py
+++ b/examples/qwen_image/model_training/validate_full/Qwen-Image-Edit-2509.py
@@ -2,6 +2,7 @@ import torch
 from PIL import Image
 from diffsynth.pipelines.qwen_image import QwenImagePipeline, ModelConfig
 from diffsynth import load_state_dict
+from modelscope import dataset_snapshot_download
 
 pipe = QwenImagePipeline.from_pretrained(
     torch_dtype=torch.bfloat16,
@@ -16,6 +17,12 @@ pipe = QwenImagePipeline.from_pretrained(
 )
 state_dict = load_state_dict("models/train/Qwen-Image-Edit-2509_full/epoch-1.safetensors")
 pipe.dit.load_state_dict(state_dict)
+
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="edit/*.jpg"
+)
 
 prompt = "Change the color of the dress in Figure 1 to the color shown in Figure 2."
 images = [

--- a/examples/qwen_image/model_training/validate_full/Qwen-Image-Edit-2511.py
+++ b/examples/qwen_image/model_training/validate_full/Qwen-Image-Edit-2511.py
@@ -2,6 +2,7 @@ import torch
 from PIL import Image
 from diffsynth.pipelines.qwen_image import QwenImagePipeline, ModelConfig
 from diffsynth import load_state_dict
+from modelscope import dataset_snapshot_download
 
 pipe = QwenImagePipeline.from_pretrained(
     torch_dtype=torch.bfloat16,
@@ -16,6 +17,12 @@ pipe = QwenImagePipeline.from_pretrained(
 )
 state_dict = load_state_dict("models/train/Qwen-Image-Edit-2511_full/epoch-1.safetensors")
 pipe.dit.load_state_dict(state_dict)
+
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="edit/*.jpg"
+)
 
 prompt = "Change the color of the dress in Figure 1 to the color shown in Figure 2."
 images = [

--- a/examples/qwen_image/model_training/validate_full/Qwen-Image-Edit.py
+++ b/examples/qwen_image/model_training/validate_full/Qwen-Image-Edit.py
@@ -2,6 +2,7 @@ import torch
 from PIL import Image
 from diffsynth.pipelines.qwen_image import QwenImagePipeline, ModelConfig
 from diffsynth import load_state_dict
+from modelscope import dataset_snapshot_download
 
 pipe = QwenImagePipeline.from_pretrained(
     torch_dtype=torch.bfloat16,
@@ -16,6 +17,12 @@ pipe = QwenImagePipeline.from_pretrained(
 )
 state_dict = load_state_dict("models/train/Qwen-Image-Edit_full/epoch-1.safetensors")
 pipe.dit.load_state_dict(state_dict)
+
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="edit/image1.jpg"
+)
 
 prompt = "将裙子改为粉色"
 image = Image.open("data/example_image_dataset/edit/image1.jpg").resize((1024, 1024))

--- a/examples/qwen_image/model_training/validate_full/Qwen-Image-Layered-Control.py
+++ b/examples/qwen_image/model_training/validate_full/Qwen-Image-Layered-Control.py
@@ -2,6 +2,7 @@ from diffsynth.pipelines.qwen_image import QwenImagePipeline, ModelConfig
 from diffsynth import load_state_dict
 from PIL import Image
 import torch
+from modelscope import dataset_snapshot_download
 
 
 pipe = QwenImagePipeline.from_pretrained(
@@ -16,6 +17,12 @@ pipe = QwenImagePipeline.from_pretrained(
 )
 state_dict = load_state_dict("models/train/Qwen-Image-Layered-Control_full/epoch-1.safetensors")
 pipe.dit.load_state_dict(state_dict)
+
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="layer/image.png"
+)
 prompt = "Text 'HELLO' and 'Have a great day'"
 input_image = Image.open("data/example_image_dataset/layer/image.png").convert("RGBA").resize((864, 480))
 images = pipe(

--- a/examples/qwen_image/model_training/validate_full/Qwen-Image-Layered.py
+++ b/examples/qwen_image/model_training/validate_full/Qwen-Image-Layered.py
@@ -2,6 +2,7 @@ from diffsynth.pipelines.qwen_image import QwenImagePipeline, ModelConfig
 from diffsynth import load_state_dict
 from PIL import Image
 import torch
+from modelscope import dataset_snapshot_download
 
 
 pipe = QwenImagePipeline.from_pretrained(
@@ -16,6 +17,12 @@ pipe = QwenImagePipeline.from_pretrained(
 )
 state_dict = load_state_dict("models/train/Qwen-Image-Layered_full/epoch-1.safetensors")
 pipe.dit.load_state_dict(state_dict)
+
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="layer/image.png"
+)
 prompt = "a poster"
 input_image = Image.open("data/example_image_dataset/layer/image.png").convert("RGBA").resize((864, 480))
 images = pipe(

--- a/examples/qwen_image/model_training/validate_lora/FireRed-Image-Edit-1.0.py
+++ b/examples/qwen_image/model_training/validate_lora/FireRed-Image-Edit-1.0.py
@@ -1,6 +1,7 @@
 import torch
 from PIL import Image
 from diffsynth.pipelines.qwen_image import QwenImagePipeline, ModelConfig
+from modelscope import dataset_snapshot_download
 
 pipe = QwenImagePipeline.from_pretrained(
     torch_dtype=torch.bfloat16,
@@ -14,6 +15,12 @@ pipe = QwenImagePipeline.from_pretrained(
     processor_config=ModelConfig(model_id="Qwen/Qwen-Image-Edit", origin_file_pattern="processor/"),
 )
 pipe.load_lora(pipe.dit, "models/train/FireRed-Image-Edit-1.0_lora/epoch-4.safetensors")
+
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="edit/*.jpg"
+)
 
 prompt = "Change the color of the dress in Figure 1 to the color shown in Figure 2."
 images = [

--- a/examples/qwen_image/model_training/validate_lora/FireRed-Image-Edit-1.1.py
+++ b/examples/qwen_image/model_training/validate_lora/FireRed-Image-Edit-1.1.py
@@ -1,6 +1,7 @@
 import torch
 from PIL import Image
 from diffsynth.pipelines.qwen_image import QwenImagePipeline, ModelConfig
+from modelscope import dataset_snapshot_download
 
 pipe = QwenImagePipeline.from_pretrained(
     torch_dtype=torch.bfloat16,
@@ -14,6 +15,12 @@ pipe = QwenImagePipeline.from_pretrained(
     processor_config=ModelConfig(model_id="Qwen/Qwen-Image-Edit", origin_file_pattern="processor/"),
 )
 pipe.load_lora(pipe.dit, "models/train/FireRed-Image-Edit-1.1_lora/epoch-4.safetensors")
+
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="edit/*.jpg"
+)
 
 prompt = "Change the color of the dress in Figure 1 to the color shown in Figure 2."
 images = [

--- a/examples/qwen_image/model_training/validate_lora/Qwen-Image-Edit-2509.py
+++ b/examples/qwen_image/model_training/validate_lora/Qwen-Image-Edit-2509.py
@@ -1,6 +1,7 @@
 import torch
 from PIL import Image
 from diffsynth.pipelines.qwen_image import QwenImagePipeline, ModelConfig
+from modelscope import dataset_snapshot_download
 
 pipe = QwenImagePipeline.from_pretrained(
     torch_dtype=torch.bfloat16,
@@ -14,6 +15,12 @@ pipe = QwenImagePipeline.from_pretrained(
     processor_config=ModelConfig(model_id="Qwen/Qwen-Image-Edit", origin_file_pattern="processor/"),
 )
 pipe.load_lora(pipe.dit, "models/train/Qwen-Image-Edit-2509_lora/epoch-4.safetensors")
+
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="edit/*.jpg"
+)
 
 prompt = "Change the color of the dress in Figure 1 to the color shown in Figure 2."
 images = [

--- a/examples/qwen_image/model_training/validate_lora/Qwen-Image-Edit-2511.py
+++ b/examples/qwen_image/model_training/validate_lora/Qwen-Image-Edit-2511.py
@@ -1,6 +1,7 @@
 import torch
 from PIL import Image
 from diffsynth.pipelines.qwen_image import QwenImagePipeline, ModelConfig
+from modelscope import dataset_snapshot_download
 
 pipe = QwenImagePipeline.from_pretrained(
     torch_dtype=torch.bfloat16,
@@ -14,6 +15,12 @@ pipe = QwenImagePipeline.from_pretrained(
     processor_config=ModelConfig(model_id="Qwen/Qwen-Image-Edit", origin_file_pattern="processor/"),
 )
 pipe.load_lora(pipe.dit, "models/train/Qwen-Image-Edit-2511_lora/epoch-4.safetensors")
+
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="edit/*.jpg"
+)
 
 prompt = "Change the color of the dress in Figure 1 to the color shown in Figure 2."
 images = [

--- a/examples/qwen_image/model_training/validate_lora/Qwen-Image-Edit.py
+++ b/examples/qwen_image/model_training/validate_lora/Qwen-Image-Edit.py
@@ -1,6 +1,7 @@
 import torch
 from PIL import Image
 from diffsynth.pipelines.qwen_image import QwenImagePipeline, ModelConfig
+from modelscope import dataset_snapshot_download
 
 pipe = QwenImagePipeline.from_pretrained(
     torch_dtype=torch.bfloat16,
@@ -14,6 +15,12 @@ pipe = QwenImagePipeline.from_pretrained(
     processor_config=ModelConfig(model_id="Qwen/Qwen-Image-Edit", origin_file_pattern="processor/"),
 )
 pipe.load_lora(pipe.dit, "models/train/Qwen-Image-Edit_lora/epoch-4.safetensors")
+
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="edit/image1.jpg"
+)
 
 prompt = "将裙子改为粉色"
 image = Image.open("data/example_image_dataset/edit/image1.jpg").resize((1024, 1024))

--- a/examples/qwen_image/model_training/validate_lora/Qwen-Image-EliGen-Poster.py
+++ b/examples/qwen_image/model_training/validate_lora/Qwen-Image-EliGen-Poster.py
@@ -1,6 +1,7 @@
 from diffsynth.pipelines.qwen_image import QwenImagePipeline, ModelConfig
 import torch
 from PIL import Image
+from modelscope import dataset_snapshot_download
 
 
 pipe = QwenImagePipeline.from_pretrained(
@@ -14,6 +15,12 @@ pipe = QwenImagePipeline.from_pretrained(
     tokenizer_config=ModelConfig(model_id="Qwen/Qwen-Image", origin_file_pattern="tokenizer/"),
 )
 pipe.load_lora(pipe.dit, "models/train/Qwen-Image-EliGen-Poster_lora/epoch-4.safetensors")
+
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="eligen/*.png"
+)
 
 
 entity_prompts = ["A beautiful girl", "sign 'Entity Control'", "shorts", "shirt"]

--- a/examples/qwen_image/model_training/validate_lora/Qwen-Image-EliGen.py
+++ b/examples/qwen_image/model_training/validate_lora/Qwen-Image-EliGen.py
@@ -1,6 +1,7 @@
 from diffsynth.pipelines.qwen_image import QwenImagePipeline, ModelConfig
 import torch
 from PIL import Image
+from modelscope import dataset_snapshot_download
 
 
 pipe = QwenImagePipeline.from_pretrained(
@@ -14,6 +15,12 @@ pipe = QwenImagePipeline.from_pretrained(
     tokenizer_config=ModelConfig(model_id="Qwen/Qwen-Image", origin_file_pattern="tokenizer/"),
 )
 pipe.load_lora(pipe.dit, "models/train/Qwen-Image-EliGen_lora/epoch-4.safetensors")
+
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="eligen/*.png"
+)
 
 
 entity_prompts = ["A beautiful girl", "sign 'Entity Control'", "shorts", "shirt"]

--- a/examples/qwen_image/model_training/validate_lora/Qwen-Image-In-Context-Control-Union.py
+++ b/examples/qwen_image/model_training/validate_lora/Qwen-Image-In-Context-Control-Union.py
@@ -1,6 +1,7 @@
 from PIL import Image
 import torch
 from diffsynth.pipelines.qwen_image import QwenImagePipeline, ModelConfig
+from modelscope import dataset_snapshot_download
 
 pipe = QwenImagePipeline.from_pretrained(
     torch_dtype=torch.bfloat16,
@@ -13,6 +14,12 @@ pipe = QwenImagePipeline.from_pretrained(
     tokenizer_config=ModelConfig(model_id="Qwen/Qwen-Image", origin_file_pattern="tokenizer/"),
 )
 pipe.load_lora(pipe.dit, "models/train/Qwen-Image-In-Context-Control-Union_lora/epoch-4.safetensors")
+
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="canny/image_1.jpg"
+)
 image = Image.open("data/example_image_dataset/canny/image_1.jpg").resize((1024, 1024))
 prompt = "Context_Control. a dog"
 image = pipe(prompt=prompt, seed=0, context_image=image, height=1024, width=1024)

--- a/examples/qwen_image/model_training/validate_lora/Qwen-Image-Layered-Control-V2.py
+++ b/examples/qwen_image/model_training/validate_lora/Qwen-Image-Layered-Control-V2.py
@@ -15,6 +15,12 @@ pipe = QwenImagePipeline.from_pretrained(
 )
 pipe.load_lora(pipe.dit, "models/train/Qwen-Image-Layered-Control-V2_lora/epoch-4.safetensors")
 
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="layer_v2/*.png"
+)
+
 prompt = "Text 'APRIL'"
 input_image = Image.open("data/example_image_dataset/layer_v2/image_1.png").convert("RGBA").resize((1024, 1024))
 image = pipe(

--- a/examples/qwen_image/model_training/validate_lora/Qwen-Image-Layered-Control.py
+++ b/examples/qwen_image/model_training/validate_lora/Qwen-Image-Layered-Control.py
@@ -2,6 +2,7 @@ from diffsynth.pipelines.qwen_image import QwenImagePipeline, ModelConfig
 from diffsynth import load_state_dict
 from PIL import Image
 import torch
+from modelscope import dataset_snapshot_download
 
 
 pipe = QwenImagePipeline.from_pretrained(
@@ -15,6 +16,12 @@ pipe = QwenImagePipeline.from_pretrained(
     tokenizer_config=ModelConfig(model_id="Qwen/Qwen-Image", origin_file_pattern="tokenizer/"),
 )
 pipe.load_lora(pipe.dit, "models/train/Qwen-Image-Layered-Control_lora/epoch-4.safetensors")
+
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="layer/image.png"
+)
 prompt = "Text 'HELLO' and 'Have a great day'"
 input_image = Image.open("data/example_image_dataset/layer/image.png").convert("RGBA").resize((864, 480))
 images = pipe(

--- a/examples/qwen_image/model_training/validate_lora/Qwen-Image-Layered.py
+++ b/examples/qwen_image/model_training/validate_lora/Qwen-Image-Layered.py
@@ -2,6 +2,7 @@ from diffsynth.pipelines.qwen_image import QwenImagePipeline, ModelConfig
 from diffsynth import load_state_dict
 from PIL import Image
 import torch
+from modelscope import dataset_snapshot_download
 
 
 pipe = QwenImagePipeline.from_pretrained(
@@ -15,6 +16,12 @@ pipe = QwenImagePipeline.from_pretrained(
     tokenizer_config=ModelConfig(model_id="Qwen/Qwen-Image", origin_file_pattern="tokenizer/"),
 )
 pipe.load_lora(pipe.dit, "models/train/Qwen-Image-Layered_lora/epoch-4.safetensors")
+
+dataset_snapshot_download(
+    dataset_id="DiffSynth-Studio/example_image_dataset",
+    local_dir="./data/example_image_dataset",
+    allow_file_pattern="layer/image.png"
+)
 prompt = "a poster"
 input_image = Image.open("data/example_image_dataset/layer/image.png").convert("RGBA").resize((864, 480))
 images = pipe(


### PR DESCRIPTION
The `validate_full` and `validate_lora` scripts under `examples/qwen_image/model_training/` read `data/example_image_dataset/` but never fetch it.

For `edit/` and `eligen/` this is not recoverable by running things in a particular order: at `4dbf980`, nothing under `examples/qwen_image/` downloads either subdirectory. So these fail even under the ordering in `examples/dev_tools/unit_test.py`, which runs `model_inference` before `validate_lora`. Running `test_qwen_image()` on a clean checkout, 7 of the 18 scripts in `validate_lora` fail like this:

```
Traceback (most recent call last):
  File ".../validate_lora/FireRed-Image-Edit-1.0.py", line 20, in <module>
    Image.open("data/example_image_dataset/edit/image1.jpg").resize((1024, 1024)),
FileNotFoundError: [Errno 2] No such file or directory: 'data/example_image_dataset/edit/image1.jpg'
```

(`edit/image1.jpg` is fetched by `examples/boogu_image/`, so a full cross-family run rescues some of these; `edit/image_color.jpg` and `eligen/` are fetched nowhere in the repo.)

How the 18 `validate_lora` scripts divide:

- **11** read the dataset without fetching it. Of those, **7** fail as above, and **4** (`canny`, two `layer`, `layer_v2`) happen to pass because the matching `model_inference` scripts fetch that data into the same directory first.
- **3** already call `dataset_snapshot_download` (the Blockwise ControlNet scripts).
- **4** don't reference the dataset at all.

`validate_full/` has the same problem in 7 more files. The sibling `model_training/lora/*.sh` scripts don't help either way: they fetch `diffsynth_example_dataset` to a different path.

This adds the call the three existing scripts use, following their convention of naming a single file directly (`canny/image_1.jpg`, `depth/image_1.jpg`) and globbing only where several are read (`inpaint/*.jpg`):

```python
dataset_snapshot_download(
    dataset_id="DiffSynth-Studio/example_image_dataset",
    local_dir="./data/example_image_dataset",
    allow_file_pattern="edit/*.jpg"
)
```

`Qwen-Image-Layered-Control-V2.py` is included because it imports `dataset_snapshot_download` but never calls it, so a grep for the name makes it look fine.

This may also be what #1009 is asking about.

## Checking

All 11 `validate_lora` scripts were run on 1×H100 against LoRAs trained by the `model_training/lora/*.sh` scripts in the same tree, and all produced output (e.g. `Qwen-Image-Edit.py` 80s, `Qwen-Image-Edit-2509.py` 105s, `FireRed-Image-Edit-1.0.py` 124s, `Qwen-Image-EliGen.py` 50s).

To confirm the download patterns themselves rather than relying on data an earlier script had left behind, I re-ran four of them in a fresh working directory with an empty `data/`: `Qwen-Image-Edit.py` (`edit/image1.jpg`), `FireRed-Image-Edit-1.0.py` (`edit/*.jpg`), `Qwen-Image-EliGen.py` (`eligen/*.png`) and `Qwen-Image-Layered-Control.py` (`layer/image.png`). Each fetched exactly its own inputs and produced an image, covering both pattern forms.

I have **not** run the 7 `validate_full` scripts — that needs a full fine-tune, and the accelerate configs are set up for 8 GPUs. Their change is the same one-call addition, but please treat those as unverified.

The same pattern appears in `flux`, `wanvideo`, `z_image`, `mova` and `ltx2` (105 files repo-wide by the same static check, of which I have run 12). I kept this PR to `qwen_image` rather than sending a cross-family change unasked; glad to follow up on the others if that would help.
