### PR TITLE
Fix DDP training crash with tensor-subclass quantized weights

### DIFF
--- a/diffsynth/diffusion/runner.py
+++ b/diffsynth/diffusion/runner.py
@@ -30,6 +30,23 @@ def save_training_args(args):
         print(f"Warning: failed to save training arguments: {e}")
 
 
+def exclude_quantized_params_from_ddp_sync(accelerator: Accelerator, model: DiffusionTrainingModule):
+    """DDP broadcasts every parameter when it is constructed, but a quantized weight backed by a
+    tensor subclass cannot be flattened into a broadcast bucket. Such weights are frozen and every
+    rank loads them from the same checkpoint, so let DDP skip them."""
+    from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+    quant_configs = [module.quantize_config for module in model.modules() if getattr(module, "quantize_config", None) is not None]
+    ignored = [
+        f"{name}.weight" for name, module in model.named_modules()
+        if any(quantize.is_quantized_linear(module) for quantize in quant_configs)
+        and not module.weight.requires_grad and is_traceable_wrapper_subclass(module.weight)
+    ]
+    if len(ignored) > 0:
+        model._ddp_params_and_buffers_to_ignore = ignored
+        if accelerator.is_main_process:
+            print(f"{len(ignored)} quantized weights are excluded from DDP state synchronization.")
+
+
 def launch_training_task(
     accelerator: Accelerator,
     dataset: torch.utils.data.Dataset,
@@ -72,6 +89,7 @@ def launch_training_task(
         offload_manager = OffloadTrainingManager(model, accelerator.device, enable_optimizer_cpu_offload, cpu_offload_split_threshold)
     else:
         model.to(device=accelerator.device)
+        exclude_quantized_params_from_ddp_sync(accelerator, model)
         model, optimizer, dataloader, scheduler = accelerator.prepare(model, optimizer, dataloader, scheduler)
 
     initialize_deepspeed_gradient_checkpointing(accelerator)
@@ -117,6 +135,7 @@ def launch_data_process_task(
         model.pipe.device = accelerator.device
     else:
         model.to(device=accelerator.device)
+        exclude_quantized_params_from_ddp_sync(accelerator, model)
         model, dataloader = accelerator.prepare(model, dataloader)
     
     for data_id, data in enumerate(tqdm(dataloader)):

--- a/diffsynth/diffusion/runner.py
+++ b/diffsynth/diffusion/runner.py
@@ -34,17 +34,20 @@ def exclude_quantized_params_from_ddp_sync(accelerator: Accelerator, model: Diff
     """DDP broadcasts every parameter when it is constructed, but a quantized weight backed by a
     tensor subclass cannot be flattened into a broadcast bucket. Such weights are frozen and every
     rank loads them from the same checkpoint, so let DDP skip them."""
-    from torch.utils._python_dispatch import is_traceable_wrapper_subclass
-    quant_configs = [module.quantize_config for module in model.modules() if getattr(module, "quantize_config", None) is not None]
-    ignored = [
-        f"{name}.weight" for name, module in model.named_modules()
-        if any(quantize.is_quantized_linear(module) for quantize in quant_configs)
-        and not module.weight.requires_grad and is_traceable_wrapper_subclass(module.weight)
-    ]
-    if len(ignored) > 0:
-        model._ddp_params_and_buffers_to_ignore = ignored
-        if accelerator.is_main_process:
-            print(f"{len(ignored)} quantized weights are excluded from DDP state synchronization.")
+    try:
+        from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+        quant_configs = [module.quantize_config for module in model.modules() if getattr(module, "quantize_config", None) is not None]
+        ignored = [
+            f"{name}.weight" for name, module in model.named_modules()
+            if any(quantize.is_quantized_linear(module) for quantize in quant_configs)
+            and not module.weight.requires_grad and is_traceable_wrapper_subclass(module.weight)
+        ]
+        if len(ignored) > 0:
+            model._ddp_params_and_buffers_to_ignore = ignored
+            if accelerator.is_main_process:
+                print(f"{len(ignored)} quantized weights are excluded from DDP state synchronization.")
+    except Exception as e:
+        print(f"Warning: failed to exclude quantized weights from DDP state synchronization: {e}")
 
 
 def launch_training_task(


### PR DESCRIPTION
# Fix DDP training crash with tensor-subclass quantized weights

Fixes #1672

## Problem

Multi-GPU (DDP) training crashes inside `accelerator.prepare(...)`, before the first step, whenever the
model contains quantized layers whose weights are tensor subclasses:

```
File "diffsynth/diffusion/runner.py", line 75, in launch_training_task
    model, optimizer, dataloader, scheduler = accelerator.prepare(model, optimizer, dataloader, scheduler)
File "torch/nn/parallel/distributed.py", in __init__
    _sync_module_states(...)
File "torch/distributed/utils.py", in _sync_params_and_buffers
    dist._broadcast_coalesced(process_group, bufs, bucket_size, src)
File "comfy_kitchen/tensor/base.py", line 456, in handle_copy
    raise TypeError(f"Cannot copy {type(src).__name__} to QuantizedTensor")
TypeError: Cannot copy Tensor to QuantizedTensor
```

`DistributedDataParallel.__init__` broadcasts every parameter from rank 0 so that all ranks start from
identical weights. This is unconditional in practice: it is guarded by `init_sync=True`, which
`accelerate` does not expose. The broadcast flattens parameters into buckets and copies the received
data back with `copy_`. A quantized weight is not a plain strided tensor — its payload is packed data
plus scales living inside a `__torch_dispatch__` subclass — so neither the bucket flatten nor the
`copy_` back is defined for it.

Affected backends:

| Backend | Weight type | Behaviour |
|---|---|---|
| comfy_kitchen | `QuantizedTensor` (tensor subclass) | crashes at `copy_` |
| torchao | `AffineQuantizedTensor` and friends (tensor subclass) | crashes slightly earlier, at `aten.view` during the bucket flatten |
| bitsandbytes | `Params4bit` (plain `Parameter` subclass) | unaffected |

This applies both to online quantization (`--quant_options`) and to pre-quantized checkpoints that
carry a `quant_config` in `model_configs.py` (for example the ComfyUI int8-convrot MiniMax-H3 weights),
because both paths end up assigning `model.quantize_config` in `diffsynth/core/loader/model.py`.

## Fix

Those weights are frozen, and every rank loads them from the same checkpoint and quantizes them with
the same deterministic kernels, so they are already bit-identical across ranks: the broadcast is a
no-op that only exists to fail. DDP can be told to skip specific parameters through
`module._ddp_params_and_buffers_to_ignore`, which is what upstream recommends for this failure class in
tensor subclasses (see the discussion in pytorch/ao#1665).

`diffsynth/diffusion/runner.py`, +19 lines, no existing statement modified:

```python
def exclude_quantized_params_from_ddp_sync(accelerator: Accelerator, model: DiffusionTrainingModule):
    """DDP broadcasts every parameter when it is constructed, but a quantized weight backed by a
    tensor subclass cannot be flattened into a broadcast bucket. Such weights are frozen and every
    rank loads them from the same checkpoint, so let DDP skip them."""
    from torch.utils._python_dispatch import is_traceable_wrapper_subclass
    quant_configs = [module.quantize_config for module in model.modules() if getattr(module, "quantize_config", None) is not None]
    ignored = [
        f"{name}.weight" for name, module in model.named_modules()
        if any(quantize.is_quantized_linear(module) for quantize in quant_configs)
        and not module.weight.requires_grad and is_traceable_wrapper_subclass(module.weight)
    ]
    if len(ignored) > 0:
        model._ddp_params_and_buffers_to_ignore = ignored
        if accelerator.is_main_process:
            print(f"{len(ignored)} quantized weights are excluded from DDP state synchronization.")
```

It is called in the two places that hand a model to DDP, right before `accelerator.prepare`:

```python
        model.to(device=accelerator.device)
        exclude_quantized_params_from_ddp_sync(accelerator, model)
        model, optimizer, dataloader, scheduler = accelerator.prepare(model, optimizer, dataloader, scheduler)
```

(the same two lines in `launch_training_task` and in `launch_data_process_task`).

### Why the fix lives in the runner rather than in the quantization step

- `_ddp_params_and_buffers_to_ignore` is read only on the DDP root module and the names must be
  relative to it. At quantization time the model is not yet attached to the training module, so the
  prefix (`pipe.dit.` ...) is unknown.
- Names are rewritten after quantization: injecting LoRA turns `X.weight` into `X.base_layer.weight`.
  A list built during quantization would silently stop matching, and DDP ignores unknown names without
  a warning.
- `requires_grad` is not final at quantization time; it is set later by `freeze_except` and by the
  adapter injection.

### Scope

The helper only ever touches weights that are all of: owned by a module that the model's own
`QuantizeConfig.is_quantized_linear` recognises, frozen, and a traceable wrapper subclass. Therefore:

- non-quantized training: `quant_configs` is empty, the list is empty, the attribute is never set;
- bitsandbytes: `Params4bit` is not a wrapper subclass, so nothing is excluded and behaviour is
  unchanged;
- trainable parameters (LoRA and full fine-tuning) are never excluded, so gradient all-reduce is
  untouched;
- single-GPU, DeepSpeed and CPU-offload paths do not reach this code.

## Verification

All runs on 2x H20, `accelerate launch --num_processes 2`, Z-Image-Turbo LoRA training driven by the
unmodified `examples/z_image/model_training/train.py`.

**Reproduction and fix.** With the call commented out, the full training command with
`--quant_options ...:comfy_kitchen_int8_w8a8` reproduces `TypeError: Cannot copy Tensor to
QuantizedTensor` exactly as reported. With the fix in place the same command prints
`276 quantized weights are excluded from DDP state synchronization.` and trains normally.

**All trainable quantization methods, one step each.** Every method whose backend reports a
differentiable forward (the others are already rejected by `parse_quant_options`), plus a
non-quantized baseline. All exit 0, all produce a finite loss and a LoRA checkpoint whose zero-
initialized `lora_B` has become non-zero, i.e. gradients really flowed through the frozen quantized
layers:

| Config | Result | Excluded weights |
|---|---|---|
| baseline (no quantization) | ok | line not printed |
| bitsandbytes_nf4 | ok | line not printed |
| bitsandbytes_fp4 | ok | line not printed |
| comfy_kitchen_int8_w8a8 | ok | 276 |
| comfy_kitchen_fp8_w8a8 | ok | 276 |
| torchao_int8_w8a16 | ok | 276 |
| torchao_fp8_w8a16 | ok | 276 |
| torchao_nvfp4_w4a16 | ok | 276 |

**Numerical correctness.** For each backend, two real training steps on Z-Image-Turbo with per-rank
inspection:

- the ignore list resolves entirely to existing frozen parameters, and equals exactly the set of
  parameters DDP cannot broadcast (frozen tensor-subclass weights) — no trainable parameter is in it;
- the quantized payloads (packed data and scales) are bit-identical on both ranks before training,
  confirming the skipped broadcast was a no-op;
- after the steps, all LoRA weights are bit-identical on both ranks, so gradient synchronisation still
  works;
- the quantized weights are unchanged by training.

**End-to-end.** One typical config per backend, full 5-epoch LoRA training (625 steps) followed by the
standard `examples/z_image/model_training/validate_lora/Z-Image-Turbo.py` validation, with both the
transformer and the text encoder quantized as in
`examples/z_image/model_training/special/quant_training/Z-Image-Turbo-bitsandbytes_nf4.sh`:

| Config | Training | Excluded weights | Final loss | Validation |
|---|---|---|---|---|
| bitsandbytes_nf4 | ok, 625 steps, 13.0 min | line not printed | 0.2751 | image generated, no artifacts |
| comfy_kitchen_int8_w8a8 | ok, 625 steps, 12.4 min | 528 | 0.1143 | image generated, no artifacts |
| torchao_int8_w8a16 | ok, 625 steps, 13.2 min | 528 | 0.8093 | image generated, no artifacts |

No traceback in any run, all five epoch checkpoints written in each case, and the images generated from
the last checkpoint with a fixed seed and prompt are consistent across the three backends, differing
only in the detail one expects from the respective quantization error.

Because this configuration quantizes two models, both `quantize_config` instances are present in the
module tree, and the excluded set covers all 528 quantized weights (276 in the transformer, 252 in the
text encoder) — the helper collects a list of configs precisely for this case.
