### PR TITLE
fix(wan): un-shadow XLMRoberta's SelfAttention/AttentionBlock in wan_video_image_encoder

### DIFF
--- a/diffsynth/models/wan_video_image_encoder.py
+++ b/diffsynth/models/wan_video_image_encoder.py
@@ -11,7 +11,7 @@ import torchvision.transforms as T
 from .wan_video_dit import flash_attention
 
 
-class SelfAttention(nn.Module):
+class XLMRobertaSelfAttention(nn.Module):
 
     def __init__(self, dim, num_heads, dropout=0.1, eps=1e-5):
         assert dim % num_heads == 0
@@ -50,7 +50,7 @@ class SelfAttention(nn.Module):
         return x
 
 
-class AttentionBlock(nn.Module):
+class XLMRobertaAttentionBlock(nn.Module):
 
     def __init__(self, dim, num_heads, post_norm, dropout=0.1, eps=1e-5):
         super().__init__()
@@ -60,7 +60,7 @@ class AttentionBlock(nn.Module):
         self.eps = eps
 
         # layers
-        self.attn = SelfAttention(dim, num_heads, dropout, eps)
+        self.attn = XLMRobertaSelfAttention(dim, num_heads, dropout, eps)
         self.norm1 = nn.LayerNorm(dim, eps=eps)
         self.ffn = nn.Sequential(
             nn.Linear(dim, dim * 4), nn.GELU(), nn.Linear(dim * 4, dim),
@@ -112,7 +112,7 @@ class XLMRoberta(nn.Module):
 
         # blocks
         self.blocks = nn.ModuleList([
-            AttentionBlock(dim, num_heads, post_norm, dropout, eps)
+            XLMRobertaAttentionBlock(dim, num_heads, post_norm, dropout, eps)
             for _ in range(num_layers)
         ])
 


### PR DESCRIPTION
### Problem

`diffsynth/models/wan_video_image_encoder.py` is a merge of two upstream modules — the
XLM-RoBERTa text tower and the CLIP vision tower. Both halves define module-level
`SelfAttention` and `AttentionBlock`:

| name | XLM-RoBERTa version | CLIP version (wins) |
|---|---|---|
| `SelfAttention` | L14–50 | L234–268 |
| `AttentionBlock` | L53–77 | L289–330 |

Python keeps the **last** module-level binding, so the two classes at the top of the file
are unreachable and `XLMRoberta` silently picks up the CLIP blocks instead:

```python
# XLMRoberta.__init__, L115 — XLM-RoBERTa argument order
AttentionBlock(dim, num_heads, post_norm, dropout, eps)
# resolves to the CLIP signature
#   (dim, mlp_ratio, num_heads, post_norm=False, causal=False, ...)
```

Nothing raises at construction time, because `assert dim % num_heads == 0` happens to pass
(`1024 % True == 0`).

### Reproduction

Constructing `XLMRoberta(dim=1024, num_heads=16, num_layers=2, post_norm=True, dropout=0.1, eps=1e-5)`
and calling it on `torch.randint(2, 100, (1, 8))`:

| | before | after |
|---|---|---|
| block class | `AttentionBlock` (CLIP, L289) | `XLMRobertaAttentionBlock` (L53) |
| `attn.num_heads` | `True` | `16` |
| `attn.head_dim` | `1024` | `64` |
| MLP attribute | `mlp` (`mlp_ratio=16`) | `ffn` (`dim*4`) |
| params / block | 37,774,336 | 12,596,224 |
| `forward(ids)` | `TypeError: AttentionBlock.forward() takes 2 positional arguments but 3 were given` | ✅ `(1, 8, 1024)` |

The `TypeError` comes from the CLIP block's `forward(self, x)` having no `mask` parameter.

### Fix

Rename the two shadowed definitions to `XLMRobertaSelfAttention` / `XLMRobertaAttentionBlock`
and update their two call sites. Four lines.

### The CLIP / vision path is untouched

`WanImageEncoder` uses only `model.visual`, and this change does not move or alter the CLIP
definitions. Comparing the module-level bindings before and after with `ast.dump`:

```
names whose runtime binding CHANGED: ['XLMRoberta']
names ADDED  : ['XLMRobertaAttentionBlock', 'XLMRobertaSelfAttention']
names REMOVED: []
SelfAttention  : binding identical before/after -> True
AttentionBlock : binding identical before/after -> True
```

So `SelfAttention`, `AttentionBlock`, `VisionTransformer`, `AttentionPool`, `CLIP`,
`XLMRobertaCLIP` and `WanImageEncoder` are bit-for-bit the same as on `main`; the only
behaviour that changes is `XLMRoberta`, which previously could not run at all.

Note that `XLMRobertaCLIP` sets `self.textual = None`, so the text tower is not reached from
the Wan video pipeline today — this is a latent bug in the module's public
`XLMRoberta` / `XLMRobertaWithHead` / `xlm_roberta_large` API rather than a pipeline
regression. Happy to instead drop the dead text tower entirely if you'd prefer that direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
